### PR TITLE
Add support for external md files in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Use the following structure for the files:
            /<version>                 -- ktor version range w/ special chars stripped
              /manifest.ktor.yaml      -- use template templates/manifest.ktor.yaml
              /install.kt              -- contains install function
+             /documentation.md        -- contains documentation
 ```
 
 You can include any number of install files for populating new projects.  More information under 

--- a/plugins/server/io.ktor/csrf/3.0.0-beta-2/documentation.md
+++ b/plugins/server/io.ktor/csrf/3.0.0-beta-2/documentation.md
@@ -1,0 +1,20 @@
+This plugin provides mitigations for cross-site request forgery (CSRF).
+
+There are several ways to prevent CSRF attacks, each with different pros / cons depending on how
+your website is structured.  The [OWASP cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+enumerates the mitigations provided here.
+
+## Usage
+
+```kotlin
+install(CSRF) {
+    // tests Origin is an expected value
+    allowOrigin("http://localhost:8080")
+    
+    // tests Origin matches Host header
+    originMatchesHost()
+    
+    // custom header checks
+    checkHeader("X-CSRF-Token")
+}
+```

--- a/plugins/server/io.ktor/csrf/3.0.0-beta-2/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/csrf/3.0.0-beta-2/manifest.ktor.yaml
@@ -3,24 +3,3 @@ description: Cross-site request forgery mitigation
 vcsLink: https://github.com/ktorio/ktor/blob/main/ktor-server/ktor-server-plugins/ktor-server-csrf/jvmAndNix/src/io/ktor/server/plugins/csrf/CSRF.kt
 copyright: Apache 2.0
 category: Security
-documentation:
-    description: |
-        This plugin provides mitigations for cross-site request forgery (CSRF).
-        
-        There are several ways to prevent CSRF attacks, each with different pros / cons depending on how
-        your website is structured.  The [OWASP cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
-        enumerates the mitigations provided here.
-    
-    usage: |
-        ```kotlin
-        install(CSRF) {
-            // tests Origin is an expected value
-            allowOrigin("http://localhost:8080")
-            
-            // tests Origin matches Host header
-            originMatchesHost()
-            
-            // custom header checks
-            checkHeader("X-CSRF-Token")
-        }
-        ```

--- a/src/main/kotlin/io/ktor/plugins/registry/Documentation.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/Documentation.kt
@@ -1,0 +1,19 @@
+package io.ktor.plugins.registry
+
+object DocumentationExtractor {
+    private val usageRegex = Regex("\n#+\\s*Usage\\s\n", setOf(RegexOption.IGNORE_CASE, RegexOption.MULTILINE))
+
+    fun parseDocumentationMarkdown(contents: String): DocumentationEntry =
+        try {
+            usageRegex.split(contents).map(String::trim).let { (description, usage) ->
+                DocumentationEntry(description, usage)
+            }
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Missing usage section in documentation: \n$contents")
+        }
+}
+
+data class DocumentationEntry(
+    val description: String,
+    val usage: String,
+)

--- a/src/test/kotlin/io/ktor/plugins/registry/DocumentationExtractorTest.kt
+++ b/src/test/kotlin/io/ktor/plugins/registry/DocumentationExtractorTest.kt
@@ -1,0 +1,51 @@
+package io.ktor.plugins.registry
+
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DocumentationExtractorTest {
+
+    @Test
+    fun `extracts documentation`() {
+        val documentation = DocumentationExtractor.parseDocumentationMarkdown("""
+            This plugin does some stuff.
+            
+            # Usage
+            
+            First, do the thing with the stuff:
+            
+            ```kotlin
+            doCode()
+            ```
+        """.trimIndent())
+
+        val (description, usage) = documentation
+
+        assertEquals("""
+            This plugin does some stuff.
+        """.trimIndent(), description)
+
+        assertEquals("""
+            First, do the thing with the stuff:
+            
+            ```kotlin
+            doCode()
+            ```
+        """.trimIndent(), usage)
+    }
+
+    @Test
+    fun `usage is required`() {
+        assertThrows<IllegalArgumentException> {
+            DocumentationExtractor.parseDocumentationMarkdown("""
+                Some documentation that forgot usage.
+                
+                ```kotlin
+                doCode
+                ```
+            """.trimIndent())
+        }
+    }
+
+}

--- a/templates/documentation.md
+++ b/templates/documentation.md
@@ -1,0 +1,16 @@
+
+A longer description here which is shown after selecting the plugin listing.  
+
+More details are provided here.
+
+## Usage
+
+The usage section is REQUIRED.
+
+Here you can find a short description of how to use the plugin, along with code snippets.
+
+```kotlin
+install(Sample) {
+    sampleProperty = "property.value"    
+}
+```

--- a/templates/manifest.ktor.yaml
+++ b/templates/manifest.ktor.yaml
@@ -9,30 +9,28 @@ category: Routing
 # Plugin ID references which are required for this
 prerequisites:
   - other.plugin.id
-documentation:
-  description: |
-    A longer description here which is shown after selecting the plugin listing.  More details are provided here.
-  usage: |
-    Usage is a short description of how to use the plugin, supporting markdown for code snippets.
-    
-    ```kotlin
-    install(Sample) {
-        sampleProperty = "property.value"    
-    }
-    ```
-
+# Documentation can either be a file reference or string
+# Optional, defaults to documentation.md
+documentation: documentation.md
+# Formatted options shown at the bottom of documentation.
+# Optional, defaults to empty
+options:
+  - name: option1
+    default: some_value
+    description: defines the first option
 # (location, kotlin) pairs, where "location" is a pre-defined injection point, and "kotlin" is either a path or inline code
 #   options for "location" include:
-#     default: placed in the category's install file
-#     in_routing: underneath the `routing` configuration
-#     application_conf: in the application.conf file
-#     application_yaml: in the application.yaml file
-#     inside_app: add snippet to the application
-#     outside_app: top-level of main kotlin file, outside application scope
-#     call_logging_config: inside the call logging configuration block
-#     serialization_config: inside the serialization configuration block
-#     source_file_kt: in a separate file
-#     test_function: adds a function to the test suite
-#     resources: adds a file to the project's resources
+#   - default: placed in the *category*'s install file
+#   - in_routing: underneath the `routing` configuration
+#   - application_conf: in the application.conf file
+#   - application_yaml: in the application.yaml file
+#   - inside_app: add snippet to the application
+#   - outside_app: top-level of main kotlin file, outside application scope
+#   - call_logging_config: inside the call logging configuration block
+#   - serialization_config: inside the serialization configuration block
+#   - source_file_kt: in a separate file
+#   - test_function: adds a function to the test suite
+#   - resources: adds a file to the project's resources
+# Optional, defaults to install.kt
 installation:
   default: install.kt


### PR DESCRIPTION
Now you can include `documentation.md` in your plugin folder to provide for supplying the description / usage.  Optionally, you can provide a path to some other file or keep the markdown inline in the yaml.