### PR TITLE
Add json schemas for yaml config files

### DIFF
--- a/.idea/jsonSchemas.xml
+++ b/.idea/jsonSchemas.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JsonSchemaMappingsProjectConfiguration">
+    <state>
+      <map>
+        <entry key="Ktor plugin group">
+          <value>
+            <SchemaInfo>
+              <option name="generatedName" value="New Schema" />
+              <option name="name" value="Ktor plugin group" />
+              <option name="relativePathToSchema" value="templates/schema/group-schema.json" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="path" value="plugins/*/*/group.ktor.yaml" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
+        <entry key="Ktor plugin manifest">
+          <value>
+            <SchemaInfo>
+              <option name="generatedName" value="New Schema" />
+              <option name="name" value="Ktor plugin manifest" />
+              <option name="relativePathToSchema" value="templates/schema/manifest-schema.json" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="path" value="plugins/*/*/*/*/manifest.ktor.yaml" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
+        <entry key="Ktor versions mapping">
+          <value>
+            <SchemaInfo>
+              <option name="generatedName" value="New Schema" />
+              <option name="name" value="Ktor versions mapping" />
+              <option name="relativePathToSchema" value="templates/schema/version-schema.json" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="path" value="plugins/*/*/*/versions.ktor.yaml" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
+      </map>
+    </state>
+  </component>
+</project>

--- a/templates/schema/group-schema.json
+++ b/templates/schema/group-schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://ktor.io/group.yaml.json",
+  "properties": {
+    "name": {
+      "description": "The name of your organization",
+      "type": "string",
+      "maxLength": 80,
+      "minLength": 1
+    },
+    "url": {
+      "description": "A URL associated with your organization",
+      "type": "string",
+      "maxLength": 80
+    },
+    "email": {
+      "description": "An email for contacting the plugin maintainers",
+      "type": "string",
+      "maxLength": 80
+    }
+  },
+  "required": ["name"],
+  "title": "YAML schema for Ktor plugin groups",
+  "type": "object"
+}

--- a/templates/schema/manifest-schema.json
+++ b/templates/schema/manifest-schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://ktor.io/manifest.yaml.json",
+  "properties": {
+    "name": {
+      "description": "The name of your plugin",
+      "type": "string",
+      "maxLength": 80,
+      "minLength": 1
+    },
+    "description": {
+      "description": "A one-line description of the plugin",
+      "type": "string"
+    },
+    "vcsLink": {
+      "description": "A URL pointing to the plugin repository",
+      "type": "string"
+    },
+    "licence": {
+      "description": "A reference to software license used by the plugin",
+      "type": "string",
+      "maxLength": 50
+    },
+    "category": {
+      "description": "Logical grouping for the plugin where it will be configured",
+      "type": "string",
+      "maxLength": 24,
+      "enum": [
+        "Administration",
+        "Databases",
+        "HTTP",
+        "Monitoring",
+        "Routing",
+        "Security",
+        "Serialization",
+        "Sockets",
+        "Templating"
+      ]
+    },
+    "prerequisites": {
+      "description": "Plugin IDs that are also required along with this",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "options": {
+      "description": "Mapping of options available to this plugin",
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "Variable name of the property",
+              "type": "string"
+            },
+            "defaultValue": {
+              "description": "Default value of the property",
+              "type": "string"
+            },
+            "description": {
+              "description": "Description of the property's role",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "installation": {
+      "description": "Mapping of installation snippets to be included in the generated project",
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "In category's install file",
+          "type": "string"
+        },
+        "inside_app": {
+          "description": "In Application.module() { ... } extension",
+          "type": "string"
+        },
+        "outside_app": {
+          "description": "After Application.module() { ... } extension",
+          "type": "string"
+        },
+        "in_routing": {
+          "description": "In a file, separate from Application.kt",
+          "type": "string"
+        },
+        "serialization_config": {
+          "description": "Serialization config inside install(ContentNegotiation) {...} block",
+          "type": "string"
+        },
+        "call_logging_config": {
+          "description": "CallLogging config inside install(CallLogging) {...} block",
+          "type": "string"
+        },
+        "test_function": {
+          "description": "In ApplicationTest.kt as a separate function",
+          "type": "string"
+        },
+        "resources": {
+          "description": "In application resources folder as a separate resource file",
+          "type": "string"
+        },
+        "source_file_kt": {
+          "description": "In separate file near the code",
+          "type": "string"
+        },
+        "application_conf": {
+          "description": "In application.conf file",
+          "type": "string"
+        },
+        "application_yaml": {
+          "description": "In application.yaml file",
+          "type": "string"
+        }
+      }
+    },
+    "documentation": {
+      "description": "Markdown string or file reference to populate the plugin details. Must include a 'Usage' header.",
+      "type": "string"
+    }
+  },
+  "required": ["name", "description", "vcsLink", "license", "category"],
+  "title": "YAML schema for Ktor plugin manifests",
+  "type": "object"
+}

--- a/templates/schema/version-schema.json
+++ b/templates/schema/version-schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://ktor.io/versions.yaml.json",
+  "patternProperties": {
+    "^[\\[(0-9]": {
+      "description": "Maven version range specification",
+      "type": ["string", "array"]
+    }
+  },
+  "title": "YAML schema for Ktor version mappings",
+  "type": "object"
+}


### PR DESCRIPTION
Include json schema files for easier editing of yaml files, and the IDEA config file to enforce them.  We might want to upload to https://www.schemastore.org at some point, but these files are localized to this repository and most our users will be using IDEA so I think this ought to be sufficient for now.