### PR TITLE
Change SSE category to Routing

### DIFF
--- a/plugins/server/io.ktor/sse/3.0.0-beta-1/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/sse/3.0.0-beta-1/manifest.ktor.yaml
@@ -2,7 +2,7 @@ name: Server-Sent Events (SSE)
 description: Support for server push events
 vcsLink: https://github.com/ktorio/ktor/blob/main/ktor-server/ktor-server-plugins/ktor-server-sse/jvmAndNix/src/io/ktor/server/sse/SSE.kt
 license: Apache 2.0
-category: HTTP
+category: Routing
 installation:
   default: install.kt
   in_routing: routing.kt


### PR DESCRIPTION
I was thinking that semantically, HTTP would make more sense, but it definitely belongs under Routing.