### PR TITLE
Fix for missing imports on some plugins

### DIFF
--- a/src/main/kotlin/io/ktor/plugins/registry/PluginManifests.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/PluginManifests.kt
@@ -246,15 +246,6 @@ data class YamlManifest(
             putJsonArray("imports") {
                 installSnippets.allExcept(TEST).asSequence()
                     .flatMap { (_, snippet) -> snippet.importsOrEmpty }
-                    // currently always imported anyway
-                    .filter {
-                        it !in setOf(
-                            "io.ktor.server.application.*",
-                            "io.ktor.server.routing.*",
-                            "io.ktor.server.response.*",
-                            "io.ktor.client.*"
-                        )
-                    }
                     .distinct()
                     .forEach(::add)
             }


### PR DESCRIPTION
The assumption here in the code was actually incorrect.  It was included to ensure these files matched the existing templates, but it would appear as though the imports were actually missing.