### PR TITLE
KTOR-7018 Fix DuplicatePluginException on ApplicationTest

### DIFF
--- a/plugins/server/io.ktor/routing/2.0/test.kt
+++ b/plugins/server/io.ktor/routing/2.0/test.kt
@@ -7,9 +7,6 @@ import kotlin.test.*
 class ApplicationTest {
     @Test
     fun testRoot() = testApplication {
-        application {
-            configureRouting()
-        }
         client.get("/").apply {
             assertEquals(HttpStatusCode.OK, status)
             assertEquals("Hello World!", bodyAsText())


### PR DESCRIPTION
For a quick and easy fix, removing the module config here works with yaml, hocon and code configuration options.

A better solution might be to revisit how we load config files when using the `testApplication` DSL.  It doesn't seem right that changing the configuration method of the main application would influence unit tests in this way.

I'll merge this asap since we recently updated the default configuration option to YAML, which will cause this scenario very often.