### PR TITLE
Clean up plugin short descriptions for consistency and correctness

### DIFF
--- a/plugins/server/com.kborowy/firebase-auth-provider/2.0/manifest.ktor.yaml
+++ b/plugins/server/com.kborowy/firebase-auth-provider/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Firebase authentication
-description: Handle Firebase bearer authentication
+description: Handles Firebase bearer authentication
 vcsLink: https://github.com/krizzu/firebase-auth-provider
 license: Apache 2.0
 category: Security

--- a/plugins/server/com.ucasoft/simple-cache/2.0/manifest.ktor.yaml
+++ b/plugins/server/com.ucasoft/simple-cache/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Simple Cache
-description: Simple Cache base solution which provides the plugin implementation and abstract class for cache providers
+description: Provides API for cache management
 vcsLink: https://github.com/Scogun/ktor-simple-cache/tree/main/ktor-simple-cache
 license: Apache 2.0
 category: HTTP

--- a/plugins/server/com.ucasoft/simple-memory-cache/2.0/manifest.ktor.yaml
+++ b/plugins/server/com.ucasoft/simple-memory-cache/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Simple Memory Cache
-description: Memory cache provider for Ktor Simple Cache plugin
+description: Provides memory cache for Simple Cache plugin
 vcsLink: https://github.com/Scogun/ktor-simple-cache/tree/main/ktor-simple-memory-cache
 license: Apache 2.0
 category: HTTP

--- a/plugins/server/com.ucasoft/simple-redis-cache/2.0/manifest.ktor.yaml
+++ b/plugins/server/com.ucasoft/simple-redis-cache/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Simple Redis Cache
-description: Redis cache provider for Ktor Simple Cache plugin
+description: Provides Redis cache for Simple Cache plugin
 vcsLink: https://github.com/Scogun/ktor-simple-cache/tree/main/ktor-simple-redis-cache
 license: Apache 2.0
 category: HTTP

--- a/plugins/server/io.github.cotrin8672/line-webhook/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.github.cotrin8672/line-webhook/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: LineWebhook
-description: This plugin validates the signature of LineBot webhook.
+description: Validates the signature of LineBot webhooks
 vcsLink: https://github.com/cotrin8672/ktor-line-webhook-plugin
 license: Apache 2.0
 category: Security

--- a/plugins/server/io.github.smiley4/ktor-swagger-ui/2.0/install.kt
+++ b/plugins/server/io.github.smiley4/ktor-swagger-ui/2.0/install.kt
@@ -2,7 +2,6 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.github.smiley4.ktorswaggerui.SwaggerUI
 
-// The contents of the `install` function will be used for the project template
 public fun Application.install() {
     install(SwaggerUI) {
         swagger {

--- a/plugins/server/io.github.smiley4/ktor-swagger-ui/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.github.smiley4/ktor-swagger-ui/2.0/manifest.ktor.yaml
@@ -1,10 +1,7 @@
-# This file contains all the information needed for including your plugin.
-# See templates/manifest.ktor.yaml for more details
 name: Ktor-swagger-ui
-description: Kotlin Ktor plugin to generate OpenAPI and provide Swagger UI
+description: Generates OpenAPI specification and Swagger UI
 vcsLink: https://github.com/SMILEY4/ktor-swagger-ui
 license: Apache 2.0
-# Pick one of: Administration, Databases, HTTP, Monitoring, Routing, Security, Serialization, Sockets, Templating
 category: Routing
 prerequisites:
   - io.ktor.routing

--- a/plugins/server/io.ktor/auth-basic/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/auth-basic/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Authentication Basic
-description: Handle Basic authentication
+description: Handles 'Basic' username / password authentication scheme
 vcsLink: https://github.com/ktorio/ktor/blob/4a50c76c3264b0121b91a203d38473bb4aafbace/ktor-features/ktor-auth/jvm/src/io/ktor/auth/BasicAuth.kt
 license: Apache 2.0
 category: Security

--- a/plugins/server/io.ktor/auth-digest/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/auth-digest/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Authentication Digest
-description: Handle Digest authentication
+description: Handles 'Digest' authentication scheme
 vcsLink: https://github.com/ktorio/ktor/blob/e03bafda3b3d72fcac166e46cf55e5d2d9383660/ktor-client/ktor-client-features/ktor-client-auth/common/src/io/ktor/client/features/auth/providers/DigestAuthProvider.kt
 license: Apache 2.0
 category: Security

--- a/plugins/server/io.ktor/auth-jwt/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/auth-jwt/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Authentication JWT
-description: Handle JWT authentication
+description: Handles JSON Web Token (JWT) bearer authentication scheme
 vcsLink: https://github.com/ktorio/ktor/blob/7e78e715cec3ff039cd628f8ff8ce875c35cde4c/ktor-features/ktor-auth-jwt/jvm/src/io/ktor/auth/jwt/JWTAuth.kt
 license: Apache 2.0
 category: Security

--- a/plugins/server/io.ktor/auth-ldap/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/auth-ldap/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Authentication LDAP
-description: Handle LDAP authentication
+description: Handles Lightweight Directory Access Protocol (LDAP) authentication
 vcsLink: https://github.com/ktorio/ktor/blob/4a50c76c3264b0121b91a203d38473bb4aafbace/ktor-features/ktor-auth-ldap/jvm/src/io/ktor/auth/ldap/Ldap.kt
 license: Apache 2.0
 category: Security

--- a/plugins/server/io.ktor/auth-oauth/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/auth-oauth/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Authentication OAuth
-description: Handle OAuth authentication
+description: Handles OAuth Bearer authentication scheme
 vcsLink: https://github.com/ktorio/ktor/blob/4a50c76c3264b0121b91a203d38473bb4aafbace/ktor-features/ktor-auth/jvm/src/io/ktor/auth/OAuth.kt
 license: Apache 2.0
 category: Security

--- a/plugins/server/io.ktor/auth/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/auth/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Authentication
-description: Handle Basic and Digest HTTP Auth, Form authentication and OAuth 1a and 2
+description: Provides extension point for handling the Authorization header
 vcsLink: https://github.com/ktorio/ktor/blob/4a50c76c3264b0121b91a203d38473bb4aafbace/ktor-features/ktor-auth/jvm/src/io/ktor/auth/Authentication.kt
 license: Apache 2.0
 category: Security

--- a/plugins/server/io.ktor/auto-head-response/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/auto-head-response/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: AutoHeadResponse
-description: Provide responses to HEAD requests for existing routes that have the GET verb defined
+description: Provides automatic responses for HEAD requests
 vcsLink: https://github.com/ktorio/ktor/blob/4517e3856a3cae8f157d2f6966635217827d2abd/ktor-server/ktor-server-core/jvm/src/io/ktor/features/AutoHeadResponse.kt
 license: Apache 2.0
 category: Routing

--- a/plugins/server/io.ktor/caching-headers/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/caching-headers/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Caching Headers
-description: Send the headers Cache-Control and Expires used by clients and proxies to cache requests
+description: Provides options for responding with standard cache-control headers
 vcsLink: https://github.com/ktorio/ktor/blob/419744383223899e69746b2afe50d873d442e568/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CachingHeaders.kt
 license: Apache 2.0
 category: HTTP

--- a/plugins/server/io.ktor/compression/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/compression/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Compression
-description: Compress outgoing content using gzip, deflate or custom encoder and thus reduce the size of the response
+description: Compresses responses using encoding algorithms like GZIP
 vcsLink: https://github.com/ktorio/ktor/blob/4517e3856a3cae8f157d2f6966635217827d2abd/ktor-server/ktor-server-core/jvm/src/io/ktor/features/Compression.kt
 license: Apache 2.0
 category: HTTP

--- a/plugins/server/io.ktor/conditional-headers/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/conditional-headers/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Conditional Headers
-description: Avoids sending content if the client already has the same content using ETag or LastModified
+description: Skips response body, depending on ETag and LastModified headers
 vcsLink: https://github.com/ktorio/ktor/blob/4517e3856a3cae8f157d2f6966635217827d2abd/ktor-server/ktor-server-core/jvm/src/io/ktor/features/ConditionalHeaders.kt
 license: Apache 2.0
 category: HTTP

--- a/plugins/server/io.ktor/cors/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/cors/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: CORS
-description: Enable Cross-Origin Resource Sharing (CORS)
+description: Enables Cross-Origin Resource Sharing (CORS)
 vcsLink: https://github.com/ktorio/ktor/blob/31dedb3bdaeb1e5f63ba0bfd566e63742ea7a209/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CORS.kt
 license: Apache 2.0
 category: HTTP

--- a/plugins/server/io.ktor/default-headers/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/default-headers/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Default Headers
-description: This plugin adds a default set of headers to HTTP responses
+description: Adds a default set of headers to HTTP responses
 vcsLink: https://github.com/ktorio/ktor/blob/962677f73f0900cae32e90519fa1e850dd0acfa8/ktor-server/ktor-server-core/jvm/src/io/ktor/features/DefaultHeaders.kt
 license: Apache 2.0
 category: HTTP

--- a/plugins/server/io.ktor/forwarded-header-support/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/forwarded-header-support/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Forwarded Headers
-description: This plugin allows you to handle reverse proxy headers to get information about the original request when it’s behind a proxy.
+description: Allows handling proxied headers (X-Forwarded-*)
 vcsLink: https://github.com/ktorio/ktor/blob/4517e3856a3cae8f157d2f6966635217827d2abd/ktor-server/ktor-server-core/jvm/src/io/ktor/features/OriginConnectionPoint.kt
 license: Apache 2.0
 category: HTTP

--- a/plugins/server/io.ktor/freemarker/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/freemarker/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Freemarker
-description: Serve HTML content using Apache's FreeMarker template engine
+description: Serves HTML content using Apache's FreeMarker template engine
 vcsLink: https://github.com/ktorio/ktor/blob/4a50c76c3264b0121b91a203d38473bb4aafbace/ktor-features/ktor-freemarker/jvm/src/io/ktor/freemarker/FreeMarker.kt
 license: Apache 2.0
 category: Templating

--- a/plugins/server/io.ktor/hsts/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/hsts/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: HSTS
-description: Enable HTTP Strict Transport Security (HSTS)
+description: Enables HTTP Strict Transport Security (HSTS)
 vcsLink: https://github.com/ktorio/ktor/blob/7e78e715cec3ff039cd628f8ff8ce875c35cde4c/ktor-server/ktor-server-core/jvm/src/io/ktor/features/HSTS.kt
 license: Apache 2.0
 category: HTTP

--- a/plugins/server/io.ktor/https-redirect/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/https-redirect/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: HttpsRedirect
-description: All the affected HTTP calls perform a redirect to its HTTPS counterpart before processing the call
+description: Redirects insecure HTTP requests to the respective HTTPS endpoint
 vcsLink: https://github.com/ktorio/ktor/blob/7e78e715cec3ff039cd628f8ff8ce875c35cde4c/ktor-server/ktor-server-core/jvm/src/io/ktor/features/HttpsRedirect.kt
 license: Apache 2.0
 category: HTTP

--- a/plugins/server/io.ktor/ktor-network-tls/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/ktor-network-tls/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Raw Secure SSL/TLS Sockets
-description: Adds Raw Socket support for listening and connecting to tcp and udp sockets with secure sockets
+description: Adds secure socket support for TCP and UDP
 vcsLink: https://github.com/ktorio/ktor/tree/465b7573fba8ef2293b1d8866b3842504418d6f1/ktor-network/ktor-network-tls/jvm/src/io/ktor/network/tls
 license: Apache 2.0
 category: Sockets

--- a/plugins/server/io.ktor/ktor-network/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/ktor-network/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Raw Sockets
-description: Adds Raw Socket support for listening and connecting to tcp and udp sockets
+description: Adds raw socket support for TCP and UDP
 vcsLink: https://github.com/ktorio/ktor/tree/d05996269def3ae106eb9779ac85ee448da609de/ktor-network/common/src/io/ktor/network/sockets
 license: Apache 2.0
 category: Sockets

--- a/plugins/server/io.ktor/ktor-sessions/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/ktor-sessions/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Sessions
-description: Adds supports for sessions, with the payload in the client or the server
+description: Adds supports for persistent sessions via cookies or headers
 vcsLink: https://github.com/ktorio/ktor/blob/8c5ed12666b535d88277f5307b3eb286151b18af/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/Sessions.kt
 license: Apache 2.0
 category: Security

--- a/plugins/server/io.ktor/ktor-sessions/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/ktor-sessions/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Sessions
-description: Adds supports for persistent sessions via cookies or headers
+description: Adds support for persistent sessions through cookies or headers
 vcsLink: https://github.com/ktorio/ktor/blob/8c5ed12666b535d88277f5307b3eb286151b18af/ktor-server/ktor-server-core/jvm/src/io/ktor/sessions/Sessions.kt
 license: Apache 2.0
 category: Security

--- a/plugins/server/io.ktor/ktor-websockets/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/ktor-websockets/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: WebSockets
-description: Adds WebSockets support for bidirectional communication with the client
+description: Adds WebSocket protocol support for bidirectional client connections
 vcsLink: https://github.com/ktorio/ktor/blob/4a50c76c3264b0121b91a203d38473bb4aafbace/ktor-features/ktor-websockets/jvm/src/io/ktor/websocket/WebSockets.kt
 license: Apache 2.0
 category: Sockets

--- a/plugins/server/io.ktor/mustache/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/mustache/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Mustache
-description: Serve HTML content using Mustache template engine
+description: Serves HTML content using Mustache template engine
 vcsLink: https://github.com/ktorio/ktor/blob/4a50c76c3264b0121b91a203d38473bb4aafbace/ktor-features/ktor-mustache/jvm/src/io/ktor/mustache/Mustache.kt
 license: Apache 2.0
 category: Templating

--- a/plugins/server/io.ktor/partial-content/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/partial-content/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Partial Content
-description: Handles requests with the Range header. Generating Accept-Ranges and the Content-Range headers and slicing the served content when required.
+description: Handles requests with the Range header
 vcsLink: https://github.com/ktorio/ktor/blob/4517e3856a3cae8f157d2f6966635217827d2abd/ktor-server/ktor-server-core/jvm/src/io/ktor/features/PartialContent.kt
 license: Apache 2.0
 category: HTTP

--- a/plugins/server/io.ktor/pebble/2.3/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/pebble/2.3/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Pebble
-description: Allows you to use Pebble templates as views within your application.
+description: Allows you to use Pebble templates as views within your application
 vcsLink: https://github.com/ktorio/ktor/blob/7e78e715cec3ff039cd628f8ff8ce875c35cde4c/ktor-features/ktor-pebble/jvm/src/io/ktor/pebble/Pebble.kt
 license: Apache 2.0
 category: Templating

--- a/plugins/server/io.ktor/resources/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/resources/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Resources
-description: Allows you to implement type-safe routing
+description: Provides type-safe routing
 vcsLink: https://github.com/ktorio/ktor/blob/main/ktor-shared/ktor-resources/common/src/io/ktor/resources/Resources.kt
 license: Apache 2.0
 category: Routing

--- a/plugins/server/io.ktor/routing/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/routing/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Routing
-description: Allows to define structured routes and associated handlers.
+description: Provides a structured routing DSL
 vcsLink: https://github.com/ktorio/ktor/blob/4517e3856a3cae8f157d2f6966635217827d2abd/ktor-server/ktor-server-core/jvm/src/io/ktor/routing/Routing.kt
 license: Apache 2.0
 category: Routing

--- a/plugins/server/io.ktor/shutdown-url/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/shutdown-url/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Shutdown URL
-description: This plugin enables a URL that when accessed, shutdowns the server.
+description: Enables a URL that when accessed, shuts down the server
 vcsLink: https://github.com/ktorio/ktor/blob/7e78e715cec3ff039cd628f8ff8ce875c35cde4c/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ShutDownUrl.kt
 license: Apache 2.0
 category: Administration

--- a/plugins/server/io.ktor/shutdown-url/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/shutdown-url/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Shutdown URL
-description: Enables a URL that when accessed, shuts down the server
+description: Enables a URL that shuts down the server when accessed
 vcsLink: https://github.com/ktorio/ktor/blob/7e78e715cec3ff039cd628f8ff8ce875c35cde4c/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/ShutDownUrl.kt
 license: Apache 2.0
 category: Administration

--- a/plugins/server/io.ktor/static-content/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/static-content/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Static Content
-description: Serves static files from defined locations.
+description: Serves static files from defined locations
 vcsLink: https://github.com/ktorio/ktor/blob/7e78e715cec3ff039cd628f8ff8ce875c35cde4c/ktor-server/ktor-server-core/jvm/src/io/ktor/http/content/StaticContent.kt
 license: Apache 2.0
 category: Routing

--- a/plugins/server/io.ktor/status-pages/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/status-pages/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Status Pages
-description: Allow to respond to thrown exceptions.
+description: Provides exception handling for routes
 vcsLink: https://github.com/ktorio/ktor/blob/7e78e715cec3ff039cd628f8ff8ce875c35cde4c/ktor-server/ktor-server-core/jvm/src/io/ktor/features/StatusPages.kt
 license: Apache 2.0
 category: Routing

--- a/plugins/server/io.ktor/thymeleaf/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/thymeleaf/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Thymeleaf
-description: Serve HTML content using Thymeleaf template engine
+description: Serves HTML content, templated using Thymeleaf
 vcsLink: https://github.com/ktorio/ktor/blob/7e78e715cec3ff039cd628f8ff8ce875c35cde4c/ktor-features/ktor-thymeleaf/jvm/src/io/ktor/thymeleaf/Thymeleaf.kt
 license: Apache 2.0
 category: Templating

--- a/plugins/server/io.ktor/velocity/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/velocity/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Velocity
-description: Serve HTML content using Apache's Velocity template engine
+description: Serves HTML content, templated using Apache Velocity
 vcsLink: https://github.com/ktorio/ktor/blob/7e78e715cec3ff039cd628f8ff8ce875c35cde4c/ktor-features/ktor-velocity/jvm/src/io/ktor/velocity/Velocity.kt
 license: Apache 2.0
 category: Templating

--- a/plugins/server/io.ktor/webjars/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/webjars/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Webjars
-description: Allows you to package your assets such as javascript libraries and css as part of your uber-jar.
+description: Bundles static assets into your built jar file
 vcsLink: https://github.com/ktorio/ktor/blob/7e78e715cec3ff039cd628f8ff8ce875c35cde4c/ktor-features/ktor-webjars/jvm/src/io/ktor/webjars/Webjars.kt
 license: Apache 2.0
 category: Routing

--- a/plugins/server/io.ktor/webjars/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/webjars/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Webjars
-description: Bundles static assets into your built jar file
+description: Bundles static assets into your built JAR file
 vcsLink: https://github.com/ktorio/ktor/blob/7e78e715cec3ff039cd628f8ff8ce875c35cde4c/ktor-features/ktor-webjars/jvm/src/io/ktor/webjars/Webjars.kt
 license: Apache 2.0
 category: Routing

--- a/plugins/server/org.jetbrains/css-dsl/2.0/manifest.ktor.yaml
+++ b/plugins/server/org.jetbrains/css-dsl/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: CSS DSL
-description: Generate CSS using Kotlin code
+description: Generates CSS from Kotlin DSL
 vcsLink: https://github.com/JetBrains/kotlin-wrappers/tree/master/kotlin-css
 license: Apache 2.0
 category: Templating

--- a/plugins/server/org.jetbrains/html-dsl/2.0/manifest.ktor.yaml
+++ b/plugins/server/org.jetbrains/html-dsl/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: HTML DSL
-description: Generate HTML using Kotlin code like a pure-core template engine
+description: Generates HTML from Kotlin DSL
 vcsLink: https://github.com/Kotlin/kotlinx.html
 license: Apache 2.0
 category: Templating


### PR DESCRIPTION
Went through all the plugins and cleaned up the short descriptions:

 - removed punctuation
 - removed subjects (i.e., This plugin...)
 - standardized the verbs to be 3rd person
 - condensed the description where relevant
 - random grammatical fixes
 
The motivation here is to have our list be more readable and look a little more professional, and also provide a better standard for contributors to follow.
