### PR TITLE
KTOR-7072 Export actual version numbers, fix Maven builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+.kotlin
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,10 +23,6 @@ configurations {
         target.releaseConfigs.forEach(::create)
 }
 
-kotlin {
-    jvmToolchain(11)
-}
-
 dependencies {
     // each ktor version has its own classpath
     for (target in targets) {
@@ -108,7 +104,10 @@ tasks {
     // download all sources
     compileKotlin {
         compilerOptions {
-            freeCompilerArgs.addAll("-XdownloadSources=true")
+            freeCompilerArgs.addAll(
+                "-Xcontext-receivers",
+                "-XdownloadSources=true"
+            )
         }
         dependsOn(copyPluginTypes)
     }

--- a/buildSrc/src/main/kotlin/io/ktor/plugins/registry/PluginResolution.kt
+++ b/buildSrc/src/main/kotlin/io/ktor/plugins/registry/PluginResolution.kt
@@ -6,9 +6,7 @@ package io.ktor.plugins.registry
 
 import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.encodeToStream
-import kotlinx.serialization.Serializable
 import org.gradle.api.artifacts.ResolvedArtifact
-import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.outputStream
 

--- a/src/main/kotlin/io/ktor/plugins/registry/utils/ReleaseArtifacts.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/utils/ReleaseArtifacts.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.plugins.registry.utils
+
+import io.ktor.plugins.registry.*
+import java.net.URLClassLoader
+import java.nio.file.Path
+import java.nio.file.Paths
+
+@JvmInline
+value class ReleaseArtifactsMapping(private val artifactsByRelease: Map<String, Map<String, String>>) {
+    operator fun get(release: KtorRelease): ReleaseArtifacts {
+        val artifacts = artifactsByRelease[release.versionString]
+        check(artifacts != null) { "No artifacts found for ${release.versionString}!" }
+        return ReleaseArtifacts(artifacts)
+    }
+}
+
+data class ReleaseArtifacts(
+    val references: List<ArtifactReference>,
+    val jars: List<Path>,
+) {
+    constructor(releaseArtifacts: Map<String, String>) : this(
+        references = releaseArtifacts.keys.map(ArtifactReference.Companion::parse),
+        jars = releaseArtifacts.values.map(Paths::get)
+    )
+
+    fun resolveActualVersion(artifact: ArtifactReference): ArtifactReference {
+        val versionRange = artifact.version.asRange() ?: return artifact
+        val artifactNameRegex = Regex(Regex.escape(artifact.name) + "(?:-jvm)?", RegexOption.IGNORE_CASE)
+        val actual = references.find {
+            it.group == artifact.group && artifactNameRegex.matches(it.name)
+        }
+        check(actual != null) { "Could not find actual version for $artifact" }
+        check(versionRange.contains(actual.version)) {
+            "Resolved version ${actual.version} is not in ${artifact.version} for $artifact"
+        }
+        return when(artifact.version) {
+            // keep the variable but with the actual version
+            is VersionVariable -> actual.copy(
+                version = artifact.version.copy(version = actual.version)
+            )
+            else -> actual
+        }
+    }
+
+    fun newClassloader(): URLClassLoader =
+        URLClassLoader(jars.map { it.toUri().toURL() }.toTypedArray())
+}

--- a/src/main/kotlin/io/ktor/plugins/registry/utils/ReleasePluginResolution.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/utils/ReleasePluginResolution.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.plugins.registry.utils
+
+import com.charleskorn.kaml.Yaml
+import com.charleskorn.kaml.decodeFromStream
+import io.ktor.plugins.registry.*
+import io.ktor.plugins.registry.utils.FileUtils.listImages
+import org.slf4j.LoggerFactory
+import java.io.Closeable
+import java.io.InputStream
+import java.net.URLClassLoader
+import java.nio.charset.Charset
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.inputStream
+import kotlin.io.path.toPath
+
+class ReleasePluginResolution private constructor(
+    internal val release: KtorRelease,
+    internal val releaseArtifacts: ReleaseArtifacts,
+    private val codeAnalysis: CodeAnalysis,
+    private val classLoader: URLClassLoader,
+    private val pluginsDir: Path,
+): Closeable by classLoader {
+
+    companion object {
+        fun withResolution(
+            release: KtorRelease,
+            releaseArtifacts: ReleaseArtifacts,
+            pluginsDir: Path,
+            resolution: ReleasePluginResolution.() -> Unit
+        ) = ReleasePluginResolution(
+            release = release,
+            releaseArtifacts = releaseArtifacts,
+            codeAnalysis = CodeAnalysis(releaseArtifacts.jars),
+            classLoader = releaseArtifacts.newClassloader(),
+            pluginsDir = pluginsDir
+        ).resolution()
+    }
+
+    private val logger = LoggerFactory.getLogger("PluginResolutionContext")
+
+    /**
+     * Preference goes:
+     * - prebuilt JSON
+     * - local YAML
+     * - YAML from artifacts
+     */
+    fun resolveManifest(plugin: PluginReference, assetsDir: Path): ResolvedPluginManifest? =
+        resolvePrebuiltJson(plugin)
+            ?: resolveYamlFile(plugin, assetsDir)
+            ?: resolveYamlFromClasspath(plugin, assetsDir)
+
+    private fun resolvePrebuiltJson(plugin: PluginReference): ResolvedPluginManifest? {
+        return plugin.versionPath.resolve("manifest.json").ifExists()?.let { path ->
+            logger.info("${plugin.identifier} resolved from JSON")
+            PrebuiltJsonManifest(path)
+        }
+    }
+
+    private fun resolveYamlFile(plugin: PluginReference, assetsDir: Path) =
+        plugin.versionPath.resolve("manifest.ktor.yaml").ifExists()?.let { yamlPath ->
+            val model: YamlManifest.ImportManifest =
+                yamlPath.inputStream().use(Yaml.default::decodeFromStream)
+
+            logger.info("${plugin.identifier} resolved from YAML")
+            codeAnalysis.findErrorsAndThrow(plugin.versionPath, plugin)
+
+            YamlManifest(
+                plugin = plugin,
+                model = model,
+                installSnippets = model.installation.mapValues { (site, installBlock) ->
+                    readCodeSnippet(plugin.versionPath, site, installBlock) {
+                        plugin.readFileFromVersionPath(it)
+                    }
+                },
+                documentationEntry = readDocumentation(model.documentation) {
+                    plugin.readFileFromVersionPath(it)
+                },
+                logo = assetsDir.listImages(plugin.id).firstOrNull()
+            )
+        }
+
+    private fun resolveYamlFromClasspath(plugin: PluginReference, assetsDir: Path): YamlManifest? {
+        val yamlUrl = classLoader.getResource(plugin.manifestResourceFile) ?: return null
+        val model: YamlManifest.ImportManifest = yamlUrl.openStream()
+            ?.use(Yaml.default::decodeFromStream)
+            ?: return null
+        val resolvedManifestFolder = yamlUrl.toURI().toPath().parent
+
+        logger.info("${plugin.identifier} resolved from classpath")
+        codeAnalysis.findErrorsAndThrow(resolvedManifestFolder, plugin)
+
+        return YamlManifest(
+            plugin = plugin,
+            model = model,
+            installSnippets = model.installation.mapValues { (site, installBlock) ->
+                readCodeSnippet(resolvedManifestFolder, site, installBlock) {
+                    plugin.readFileFromClasspath(it)
+                }
+            },
+            documentationEntry = readDocumentation(model.documentation) {
+                plugin.readFileFromClasspath(it)
+            },
+            logo = assetsDir.listImages(plugin.id).firstOrNull()
+        )
+    }
+
+    private val PluginReference.versionPath: Path
+        get() =
+        pluginsDir.resolve("${group.id}/$id/${versionRange.stripSpecialChars()}")
+
+    private fun PluginReference.readFileFromVersionPath(filename: String) =
+        versionPath.resolve(filename).ifExists()?.inputStream()
+
+    private fun PluginReference.readFileFromClasspath(filename: String) =
+        classLoader.getResourceAsStream("$resourcePath/${filename}")
+
+    private fun Path.ifExists(): Path? = takeIf { it.exists() }
+
+    private val PluginReference.manifestResourceFile: String get() =
+        "$resourcePath/manifest.ktor.yaml"
+
+    private val PluginReference.resourcePath: String get() =
+        "${group.id.replace('.', '/')}/$id"
+
+    private fun readCodeSnippet(
+        path: Path,
+        site: String,
+        codeSnippet: YamlManifest.CodeSnippetSource,
+        findCodeInput: (String) -> InputStream?
+    ): InstallSnippet {
+        val injectionSite = CodeInjectionSite.valueOf(site.uppercase())
+        val (code: String, filename: String?) = when (codeSnippet) {
+            is YamlManifest.CodeSnippetSource.Text -> codeSnippet.code to null
+            is YamlManifest.CodeSnippetSource.File -> {
+                val code = findCodeInput(codeSnippet.file)?.use { it.readAllBytes().toString(Charset.defaultCharset()) }
+                    ?: throw IllegalArgumentException("Missing install snippet ${codeSnippet.file}")
+                code to codeSnippet.file
+            }
+        }
+        return codeAnalysis.parseInstallSnippet(
+            sourceRoot = path,
+            site = injectionSite,
+            contents = code,
+            filename = filename
+        )
+    }
+
+    private fun readDocumentation(
+        codeSnippet: YamlManifest.CodeSnippetSource,
+        findCodeInput: (String) -> InputStream?
+    ) = DocumentationExtractor.parseDocumentationMarkdown(when (codeSnippet) {
+        is YamlManifest.CodeSnippetSource.Text -> codeSnippet.code
+        is YamlManifest.CodeSnippetSource.File -> {
+            findCodeInput(codeSnippet.file)?.use { it.readAllBytes().toString(Charset.defaultCharset()) }
+                ?: throw IllegalArgumentException("Missing documentation file ${codeSnippet.file}")
+        }
+    })
+}

--- a/src/test/kotlin/io/ktor/plugins/registry/utils/ReleaseArtifactsTest.kt
+++ b/src/test/kotlin/io/ktor/plugins/registry/utils/ReleaseArtifactsTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.plugins.registry.utils
+
+import io.ktor.plugins.registry.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class ReleaseArtifactsTest {
+
+    private val artifacts = ReleaseArtifactsMapping(
+        mapOf(
+            "2.3.11" to mapOf(
+                "org.group:one:2.4.1" to "build/repository/group/one-2.4.1.jar",
+                "org.group:two-jvm:3.2.1" to "build/repository/group/two-3.2.1.jar"
+            )
+        )
+    )
+    private val versionVariables = mapOf(
+        "one" to "1.2",
+        "two" to "3.+",
+    )
+    private val ktorRelease = KtorRelease("2.3.11")
+
+    @Test
+    fun `resolve actual version - range`() {
+        "org.group:one:2.+".shouldResolveTo("org.group:one:2.4.1")
+        "org.group:one:[2.0.0,3.0.0]".shouldResolveTo("org.group:one:2.4.1")
+        "org.group:two:3.2.+".shouldResolveTo("org.group:two-jvm:3.2.1")
+        "com.group:one:2.+".shouldNotResolve()
+        "org.group:one1:2.+".shouldNotResolve()
+        "org.group:one:2.5.+".shouldNotResolve()
+    }
+
+    @Test
+    fun `resolve actual version - number`() {
+        "org.group:one.1.2".shouldResolveTo("org.group:one.1.2")
+    }
+
+    @Test
+    fun `resolve actual version - variable`() {
+        "org.group:one:${'$'}one".shouldResolveTo("org.group:one:1.2")
+        "org.group:two:${'$'}two".shouldResolveTo("org.group:two-jvm:3.2.1")
+    }
+
+    private fun String.shouldResolveTo(expected: String) {
+        val artifactReference = ArtifactReference.parse(this, versionVariables = versionVariables)
+        val actualVersion = artifacts[ktorRelease].resolveActualVersion(artifactReference)
+        assertEquals(expected, actualVersion.toString())
+    }
+
+    private fun String.shouldNotResolve() {
+        val artifactReference = ArtifactReference.parse(this, versionVariables = versionVariables)
+        assertFailsWith<IllegalStateException>("") {
+            artifacts[ktorRelease].resolveActualVersion(artifactReference)
+        }
+    }
+
+}

--- a/src/test/kotlin/io/ktor/plugins/registry/utils/VersionsTest.kt
+++ b/src/test/kotlin/io/ktor/plugins/registry/utils/VersionsTest.kt
@@ -17,6 +17,6 @@ class VersionsTest {
     }
 
     private fun catalogVersion(name: String) =
-        CatalogVersion(name, VersionNumber("1.2.3"))
+        VersionVariable(name, VersionNumber("1.2.3"))
 
 }


### PR DESCRIPTION
This will take any references to prefix versions or version ranges like "3.+" or "[3.1,3.7)" and replace them with the currently resolved version in the registry.  This should keep things consistent in the output builds and it will fix Maven targets where prefix versions are applied (Maven does not support this notation, only Gradle)