### PR TITLE
#111 Assign version for registry fix

### DIFF
--- a/plugins/server/io.github.flaxoos/ktor-server-kafka-jvm/versions.ktor.yaml
+++ b/plugins/server/io.github.flaxoos/ktor-server-kafka-jvm/versions.ktor.yaml
@@ -1,2 +1,2 @@
 "[2.0,)":
-  - io.github.flaxoos:ktor-server-kafka-jvm:1.+
+  - io.github.flaxoos:ktor-server-kafka-jvm:1.2.9


### PR DESCRIPTION
This resolves a plugin build problem regarding the kafka plugin - caused by a missing transitive dependency (confluence 5.3.0) linked in 1.2.10. 

FYI @Flaxoos 