### PR TITLE
KTOR-7232 Fix typo in generator template

### DIFF
--- a/plugins/server/io.ktor/call-logging/3.0.0-beta-2/call_logging.kt
+++ b/plugins/server/io.ktor/call-logging/3.0.0-beta-2/call_logging.kt
@@ -1,0 +1,9 @@
+import io.ktor.server.plugins.calllogging.*
+import io.ktor.server.request.*
+import io.ktor.server.routing.*
+import org.slf4j.event.*
+
+public fun CallLoggingConfig.configureLogging() {
+    level = Level.INFO
+    filter { call -> call.request.path().startsWith("/") }
+}

--- a/plugins/server/io.ktor/call-logging/3.0.0-beta-2/documentation.md
+++ b/plugins/server/io.ktor/call-logging/3.0.0-beta-2/documentation.md
@@ -1,0 +1,16 @@
+
+Ktor provides the capability to log application events using the `SLF4J` library. The [CallLogging](https://ktor.io/docs/call-logging.html) plugin allows you to log incoming client requests.
+
+## Usage
+
+The example below shows how to add conditions for filtering requests:
+
+```kotlin
+install(CallLogging) {
+    filter { call ->
+        call.request.path().startsWith("/api/v1")
+    }
+}
+```
+
+You can learn more about other configuration capabilities from [CallLogging](https://ktor.io/docs/call-logging.html).

--- a/plugins/server/io.ktor/call-logging/3.0.0-beta-2/install.kt
+++ b/plugins/server/io.ktor/call-logging/3.0.0-beta-2/install.kt
@@ -1,0 +1,12 @@
+import io.ktor.server.application.*
+import io.ktor.server.plugins.calllogging.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import org.slf4j.event.*
+
+public fun Application.configureMonitoring() {
+    install(CallLogging) {
+        level = Level.INFO
+        filter { call -> call.request.path().startsWith("/") }
+    }
+}

--- a/plugins/server/io.ktor/call-logging/3.0.0-beta-2/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/call-logging/3.0.0-beta-2/manifest.ktor.yaml
@@ -1,0 +1,8 @@
+name: Call Logging
+description: Logs client requests
+vcsLink: https://github.com/ktorio/ktor/blob/f028b0ca428335b6545b81afef803e236242b3a5/ktor-server/ktor-server-core/jvm/src/io/ktor/features/CallLogging.kt
+license: Apache 2.0
+category: Monitoring
+installation:
+  default: install.kt
+  call_logging_config: call_logging.kt

--- a/plugins/server/io.ktor/call-logging/versions.ktor.yaml
+++ b/plugins/server/io.ktor/call-logging/versions.ktor.yaml
@@ -1,2 +1,3 @@
 "[1.4,2.0)": []
-"[2.0,)": ktor-server-call-logging-jvm:==
+"[2.0,3.0.0-beta-2)": ktor-server-call-logging-jvm:==
+"[3.0.0-beta-2,)": ktor-server-call-logging-jvm:==


### PR DESCRIPTION
This adds new plugin files for 3.0.0-beta-2 and later versions that include the typo fix for the package name of `callloging` to `calllogging`.