### PR TITLE
KTOR-7236 Fix missing @Serializable

### DIFF
--- a/plugins/server/io.ktor/ktor-sessions/2.0/routing.kt
+++ b/plugins/server/io.ktor/ktor-sessions/2.0/routing.kt
@@ -2,7 +2,9 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
+import kotlinx.serialization.*
 
+@Serializable
 data class MySession(val count: Int = 0)
 
 public fun Routing.configureRouting(mySession: MySession) {


### PR DESCRIPTION
Adds the missing annotation required for session serialization for ktor sessions.

Fixes https://youtrack.jetbrains.com/issue/KTOR-7236