### PR TITLE
Swap out Route.static with Route.staticResources, due to Route.static is deprecated

### DIFF
--- a/plugins/server/io.ktor/static-content/2.0/routing.kt
+++ b/plugins/server/io.ktor/static-content/2.0/routing.kt
@@ -5,7 +5,5 @@ import io.ktor.server.routing.*
 
 public fun Routing.configureRouting() {
     // Static plugin. Try to access `/static/index.html`
-    static("/static") {
-        resources("static")
-    }
+    staticResources("/static", "static")
 }


### PR DESCRIPTION
… is deprecated

Thanks for contributing to Ktor's plugin registry!

Before submitting your pull request, be sure to run the following:

1. `./gradlew buildRegistry`: this tests and builds the expected model for the project generator using the plugin manifests
2. `./gradlew buildTestProject`: this generates a sample project using the modified plugin files

We encourage you to experiment with the different options listed [here](https://github.com/ktorio/ktor-plugin-registry/blob/main/templates/manifest.ktor.yaml)
and explore the results in the generated test project.

Feel free to reach out with any issues with the registry or generator in a pull request or any of the channels listed [here](https://ktor.io/support/).
