### PR TITLE
KTOR-7490 Improved source file definitions

### DIFF
--- a/plugins/server/io.insert-koin/koin/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.insert-koin/koin/2.0/manifest.ktor.yaml
@@ -5,4 +5,5 @@ license: Apache 2.0
 category: Frameworks
 installation:
   default: install.kt
-  source_file_kt: HelloService.kt
+sources:
+  - file: HelloService.kt

--- a/plugins/server/org.jetbrains/mongodb/2.2,3.0.0/manifest.ktor.yaml
+++ b/plugins/server/org.jetbrains/mongodb/2.2,3.0.0/manifest.ktor.yaml
@@ -10,4 +10,5 @@ documentation: documentation.md
 installation:
   default: install.kt
   outside_app: outside_app.kt
-  source_file_kt: CarsSchema.kt
+sources:
+  - file: CarsSchema.kt

--- a/plugins/server/org.jetbrains/mongodb/3.0.0/manifest.ktor.yaml
+++ b/plugins/server/org.jetbrains/mongodb/3.0.0/manifest.ktor.yaml
@@ -10,4 +10,5 @@ documentation: documentation.md
 installation:
   default: install.kt
   outside_app: outside_app.kt
-  source_file_kt: CarsSchema.kt
+sources:
+  - file: CarsSchema.kt

--- a/plugins/server/org.jetbrains/postgres/2.2/manifest.ktor.yaml
+++ b/plugins/server/org.jetbrains/postgres/2.2/manifest.ktor.yaml
@@ -9,4 +9,5 @@ prerequisites:
 installation:
   default: install.kt
   outside_app: outside_app.kt
-  source_file_kt: CitySchema.kt
+sources:
+  - file: CitySchema.kt

--- a/src/main/kotlin/io/ktor/plugins/registry/utils/CodeAnalysis.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/utils/CodeAnalysis.kt
@@ -66,12 +66,11 @@ class CodeAnalysis(private val classpathJars: List<Path> = emptyList()) {
 
     fun parseInstallSnippet(
         sourceRoot: Path,
-        site: CodeInjectionSite,
         contents: String,
-        filename: String? = null
-    ): InstallSnippet =
+        meta: SourceCodeMeta,
+    ): CodeRef =
         pluginAnalyzer(sourceRoot)
-            .parseInstallSnippet(site, contents, filename)
+            .parseInstallSnippet(contents, meta)
 
     private fun pluginAnalyzer(sourceRoot: Path) = pluginAnalyzers.computeIfAbsent(sourceRoot) { path ->
         PluginCodeAnalyzer(
@@ -112,42 +111,34 @@ class PluginCodeAnalyzer(
         psiFileFactory = PsiFileFactory.getInstance(environment.project)
     }
 
-    fun parseInstallSnippet(site: CodeInjectionSite, contents: String, filename: String? = null): InstallSnippet =
-        when(site.extractionMethod) {
+    fun parseInstallSnippet(
+        contents: String,
+        meta: SourceCodeMeta,
+    ): CodeRef =
+        when(meta.site.extractionMethod) {
             CodeExtractionMethod.FUNCTION_BODY -> {
-                with(compileKotlinSource(contents, filename)) {
+                with(compileKotlinSource(contents, meta.file)) {
                     functionBody()?.let { codeBlock ->
-                        InstallSnippet.Kotlin(
-                            imports = importListAsStrings(),
-                            code = codeBlock
-                        )
+                        CodeRef.InjectedKotlin(codeBlock, meta.site, importListAsStrings())
                     } ?: throw IllegalArgumentException("Could not read install function:\n$contents")
                 }
             }
             CodeExtractionMethod.CLASS_BODY -> {
-                with(compileKotlinSource(contents, filename)) {
+                with(compileKotlinSource(contents, meta.file)) {
                     classBody()?.let { codeBlock ->
-                        InstallSnippet.Kotlin(
-                            imports = importListAsStrings(),
-                            code = codeBlock
-                        )
+                        CodeRef.InjectedKotlin(codeBlock, meta.site, importListAsStrings())
                     } ?: throw IllegalArgumentException("Could not read install class:\n$contents")
                 }
             }
             CodeExtractionMethod.CODE_CONTENTS -> {
-                val ktFile = compileKotlinSource(contents, filename)
+                val ktFile = compileKotlinSource(contents, meta.file)
                 val codeContents = ktFile.endOfImports()?.let { endOfImports ->
                     contents.substring(endOfImports)
                 } ?: contents
-                InstallSnippet.Kotlin(
-                    imports = ktFile.importListAsStrings(),
-                    code = codeContents.trim()
-                )
+                CodeRef.InjectedKotlin(codeContents.trim(), meta.site, ktFile.importListAsStrings())
             }
-            CodeExtractionMethod.VERBATIM -> InstallSnippet.RawContent(contents)
-            CodeExtractionMethod.FILE -> {
-                InstallSnippet.RawContent(contents, filename)
-            }
+            CodeExtractionMethod.VERBATIM -> CodeRef.SourceFile(contents, meta.site)
+            CodeExtractionMethod.FILE -> CodeRef.SourceFile(contents, meta.site, meta.file, meta.module, meta.test)
         }
 
     private fun compileKotlinSource(contents: String, filename: String? = null): KtFile =
@@ -210,20 +201,35 @@ private fun String.trimBraces() =
         substring(1, length - 1)
     else this
 
-sealed interface InstallSnippet {
-    val code: String
-    val importsOrEmpty get() = (this as? Kotlin)?.imports ?: emptyList()
 
-    data class Kotlin(
+
+sealed class CodeRef(
+    override val site: CodeInjectionSite,
+    val code: String,
+    override val module: String? = null,
+    override val test: Boolean = false,
+): SourceCodeMeta {
+    val importsOrEmpty get() = (this as? InjectedKotlin)?.imports ?: emptyList()
+
+    class InjectedKotlin(
+        code: String,
+        site: CodeInjectionSite,
         val imports: List<String>,
-        override val code: String,
-    ) : InstallSnippet
+    ) : CodeRef(site, code) {
+        override val file: String? get() = null
+    }
 
-    data class RawContent(
-        override val code: String,
-        val filename: String? = null
-    ) : InstallSnippet
+    class SourceFile(
+        code: String,
+        site: CodeInjectionSite = CodeInjectionSite.SOURCE_FILE_KT,
+        override val file: String? = null,
+        module: String? = null,
+        test: Boolean = false,
+    ) : CodeRef(site, code, module, test)
 }
+
+fun CodeRef.isMainInjectionSite() =
+    this is CodeRef.InjectedKotlin && site != CodeInjectionSite.TEST_FUNCTION
 
 data class CompilationError(
     val file: String,
@@ -231,58 +237,3 @@ data class CompilationError(
     val column: Int?,
     val message: String,
 )
-
-// What bits of the code to use for injection
-enum class CodeExtractionMethod {
-    // pulls the body out of the function declaration found in this file
-    FUNCTION_BODY,
-    // uses the contents of the class declaration to be injected into another class
-    CLASS_BODY,
-    // extracts all top-level declarations for the code, excluding imports
-    CODE_CONTENTS,
-    // 1:1 copy of file contents
-    VERBATIM,
-    // 1:1 copy of file contents, preserving file name
-    FILE
-}
-
-// Intended destination of a code snippet in the generated project
-enum class CodeInjectionSite(
-    val extractionMethod: CodeExtractionMethod,
-    val defaultFileLocation: String? = null,
-) {
-    // In category's install file
-    DEFAULT(CodeExtractionMethod.FUNCTION_BODY, "install.kt"),
-
-    // In Application.module() { ... } extension:
-    INSIDE_APP(CodeExtractionMethod.FUNCTION_BODY, "inside_app.kt"),
-
-    // After Application.module() { ... } extension:
-    OUTSIDE_APP(CodeExtractionMethod.CODE_CONTENTS, "outside_app.kt"),
-
-    // In a file, separate from Application.kt:
-    IN_ROUTING(CodeExtractionMethod.FUNCTION_BODY, "routing.kt"),
-
-    // Serialization config inside install(ContentNegotiation) {...} block:
-    SERIALIZATION_CONFIG(CodeExtractionMethod.FUNCTION_BODY, "content_negotiation.kt"),
-
-    // CallLogging config inside install(CallLogging) {...} block:
-    CALL_LOGGING_CONFIG(CodeExtractionMethod.FUNCTION_BODY, "call_logging.kt"),
-
-    // In ApplicationTest.kt as a separate function:
-    TEST_FUNCTION(CodeExtractionMethod.CLASS_BODY, "test.kt"),
-
-    // In application resources folder as a separate resource file
-    RESOURCES(CodeExtractionMethod.FILE),
-
-    // In separate file near the code
-    SOURCE_FILE_KT(CodeExtractionMethod.FILE),
-
-    // In application.conf file
-    APPLICATION_CONF(CodeExtractionMethod.VERBATIM, "application.conf"),
-
-    // In application.yaml file
-    APPLICATION_YAML(CodeExtractionMethod.VERBATIM, "application.yaml");
-
-    val lowercaseName: String get() = name.lowercase()
-}

--- a/src/main/kotlin/io/ktor/plugins/registry/utils/PluginManifests.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/utils/PluginManifests.kt
@@ -176,7 +176,7 @@ data class YamlManifest(
                 addJsonObject {
                     put("group", dependency.group)
                     put("artifact", dependency.name)
-                    put("version", when (val version = dependency.version) {
+                    put("version", when(val version = dependency.version) {
                         is VersionNumber -> version.toString()
                         is VersionRange -> version.toString()
                         is VersionVariable -> version.normalizedName
@@ -185,6 +185,9 @@ data class YamlManifest(
                     })
                     if (dependency.version is VersionVariable)
                         put("version_value", dependency.version.toString())
+                    dependency.version.asRange()?.let { range ->
+                        put("version_range", range.toString())
+                    }
                 }
             }
         }

--- a/src/main/kotlin/io/ktor/plugins/registry/utils/PluginManifests.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/utils/PluginManifests.kt
@@ -16,13 +16,12 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.*
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import org.jetbrains.kotlin.utils.mapToSetOrEmpty
-import org.slf4j.LoggerFactory
-import java.io.InputStream
 import java.net.MalformedURLException
 import java.net.URL
 import java.nio.file.Files
 import java.nio.file.Path
-import kotlin.io.path.*
+import kotlin.io.path.name
+import kotlin.io.path.outputStream
 
 sealed interface ResolvedPluginManifest {
     fun validate(release: KtorRelease)
@@ -50,7 +49,7 @@ data class PrebuiltJsonManifest(private val path: Path) : ResolvedPluginManifest
 data class YamlManifest(
     private val plugin: PluginReference,
     private val model: ImportManifest,
-    private val installSnippets: Map<String, InstallSnippet>,
+    private val codeRefs: List<CodeRef>,
     private val documentationEntry: DocumentationEntry,
     private val logo: Path?,
 ): ResolvedPluginManifest {
@@ -133,37 +132,40 @@ data class YamlManifest(
     private fun JsonObjectBuilder.putInstallRecipe() {
         putJsonObject("install_recipe") {
             putJsonArray("imports") {
-                installSnippets.allExcept(TEST).asSequence()
-                    .flatMap { (_, snippet) -> snippet.importsOrEmpty }
+                codeRefs.asSequence()
+                    .filter { it.isMainInjectionSite() }
+                    .flatMap { it.importsOrEmpty }
                     .distinct()
                     .forEach(::add)
             }
-            installSnippets[DEFAULT]?.let { defaultInstall ->
-                put("install_block", defaultInstall.code)
+            codeRefs.find { it.site == CodeInjectionSite.DEFAULT }?.let { ref ->
+                put("install_block", ref.code)
             }
-            installSnippets[TEST]?.let { testFunctionInstall ->
+            codeRefs.find { it.site == CodeInjectionSite.TEST_FUNCTION }?.let { ref ->
                 putJsonArray("test_imports") {
-                    testFunctionInstall.importsOrEmpty.forEach(::add)
+                    ref.importsOrEmpty.forEach(::add)
                 }
                 // function template will be included in the following section
             }
-            installSnippets.allExcept(DEFAULT).takeIf { it.isNotEmpty() }?.let { templateSnippets ->
+            codeRefs.filter { it.site != CodeInjectionSite.DEFAULT }.takeIf { it.isNotEmpty() }?.let { refs ->
                 putJsonArray("templates") {
-                    for ((position, snippet) in templateSnippets)
+                    for (ref in refs)
                         add(buildJsonObject {
-                            put("position", position)
-                            put("text", snippet.code)
-                            (snippet as? InstallSnippet.RawContent)?.filename?.let {
-                                put("name", it)
+                            put("position", ref.site.lowercaseName)
+                            put("text", ref.code)
+                            when(ref) {
+                                is CodeRef.InjectedKotlin -> {}
+                                is CodeRef.SourceFile -> {
+                                    if (ref.file != null) put("name", ref.file)
+                                    if (ref.module != null) put("module", ref.module)
+                                    if (ref.test) put("test", true)
+                                }
                             }
                         })
                 }
             }
         }
     }
-
-    private fun Map<String, InstallSnippet>.allExcept(site: String) =
-        entries.filter { (key) -> key != site }
 
     context(ReleasePluginResolution)
     private fun JsonObjectBuilder.putDependencies(release: KtorRelease) {
@@ -261,6 +263,8 @@ data class YamlManifest(
         val options: List<ImportOption>? = null,
         val installation: Map<String, CodeSnippetSource> =
             mapOf(CodeInjectionSite.DEFAULT.lowercaseName to CodeSnippetSource.File("install.kt")),
+        val sources: List<CustomSourceFileTemplate> = emptyList(),
+        val resources: List<CustomSourceFileTemplate> = emptyList(),
         val gradle: GradleInstallRecipe? = null,
         val maven: MavenInstallRecipe? = null,
     )
@@ -307,6 +311,13 @@ data class YamlManifest(
         val artifact: String,
         val version: String? = null,
         val extra: String? = null
+    )
+
+    @Serializable
+    data class CustomSourceFileTemplate(
+        val file: String,
+        val module: String? = null,
+        val test: Boolean = false,
     )
 
     @Serializable(with = CodeBlockSerializer::class)

--- a/src/main/kotlin/io/ktor/plugins/registry/utils/SourceCodeMeta.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/utils/SourceCodeMeta.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package io.ktor.plugins.registry.utils
+
+// General details for source code injection
+interface SourceCodeMeta {
+    val site: CodeInjectionSite
+    val file: String? get() = null
+    val module: String? get() = null
+    val test: Boolean get() = false
+}
+
+// Intended destination of a code snippet in the generated project
+enum class CodeInjectionSite(
+    val extractionMethod: CodeExtractionMethod,
+    val defaultFileLocation: String? = null,
+) {
+    // In category's install file
+    DEFAULT(CodeExtractionMethod.FUNCTION_BODY, "install.kt"),
+
+    // In Application.module() { ... } extension:
+    INSIDE_APP(CodeExtractionMethod.FUNCTION_BODY, "inside_app.kt"),
+
+    // After Application.module() { ... } extension:
+    OUTSIDE_APP(CodeExtractionMethod.CODE_CONTENTS, "outside_app.kt"),
+
+    // In a file, separate from Application.kt:
+    IN_ROUTING(CodeExtractionMethod.FUNCTION_BODY, "routing.kt"),
+
+    // Serialization config inside install(ContentNegotiation) {...} block:
+    SERIALIZATION_CONFIG(CodeExtractionMethod.FUNCTION_BODY, "content_negotiation.kt"),
+
+    // CallLogging config inside install(CallLogging) {...} block:
+    CALL_LOGGING_CONFIG(CodeExtractionMethod.FUNCTION_BODY, "call_logging.kt"),
+
+    // In ApplicationTest.kt as a separate function:
+    TEST_FUNCTION(CodeExtractionMethod.CLASS_BODY, "test.kt"),
+
+    // In application resources folder as a separate resource file
+    RESOURCES(CodeExtractionMethod.FILE),
+
+    // In separate file near the code
+    SOURCE_FILE_KT(CodeExtractionMethod.FILE),
+
+    // In application.conf file
+    APPLICATION_CONF(CodeExtractionMethod.VERBATIM, "application.conf"),
+
+    // In application.yaml file
+    APPLICATION_YAML(CodeExtractionMethod.VERBATIM, "application.yaml");
+
+    val lowercaseName: String get() = name.lowercase()
+}
+
+// What bits of the code to use for injection
+enum class CodeExtractionMethod {
+    // pulls the body out of the function declaration found in this file
+    FUNCTION_BODY,
+    // uses the contents of the class declaration to be injected into another class
+    CLASS_BODY,
+    // extracts all top-level declarations for the code, excluding imports
+    CODE_CONTENTS,
+    // 1:1 copy of file contents
+    VERBATIM,
+    // 1:1 copy of file contents, preserving file name
+    FILE
+}
+
+fun CodeInjectionSite.asMeta(
+    file: String? = null,
+    module: String? = null,
+    test: Boolean = false,
+) = object : SourceCodeMeta {
+    override val site = this@asMeta
+    override val file = file
+    override val module = module
+    override val test = test
+}

--- a/src/test/kotlin/io/ktor/plugins/registry/utils/PluginCodeAnalyzerTest.kt
+++ b/src/test/kotlin/io/ktor/plugins/registry/utils/PluginCodeAnalyzerTest.kt
@@ -4,6 +4,7 @@
 
 package io.ktor.plugins.registry.utils
 
+import io.ktor.util.reflect.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/io/ktor/plugins/registry/utils/PluginCodeAnalyzerTest.kt
+++ b/src/test/kotlin/io/ktor/plugins/registry/utils/PluginCodeAnalyzerTest.kt
@@ -24,43 +24,41 @@ class PluginCodeAnalyzerTest {
     @Test
     fun `read install snippet verbatim`() {
         val result = pluginCodeAnalyzer.parseInstallSnippet(
-            CodeInjectionSite.SOURCE_FILE_KT,
             KOTLIN_CODE.trimIndent(),
-            "Test.kt"
+            CodeInjectionSite.SOURCE_FILE_KT.asMeta(file = "Test.kt"),
         )
 
-        assertEquals(InstallSnippet.RawContent(KOTLIN_CODE.trimIndent(), "Test.kt"), result)
+        assertEquals(KOTLIN_CODE.trimIndent(), result.code)
+        assertEquals(CodeInjectionSite.SOURCE_FILE_KT, result.site)
+        assertEquals(emptyList(), result.importsOrEmpty)
+        assertEquals("Test.kt", result.file)
     }
 
     @Test
     fun `read install snippet from kotlin`() {
-        val result = pluginCodeAnalyzer.parseInstallSnippet(CodeInjectionSite.DEFAULT, KOTLIN_CODE.trimIndent())
+        val result = pluginCodeAnalyzer.parseInstallSnippet(
+            KOTLIN_CODE.trimIndent(),
+            CodeInjectionSite.DEFAULT.asMeta()
+        )
 
-        assertEquals(
-            InstallSnippet.Kotlin(
-            imports = listOf(
-                "java.nio.file.Paths",
-            ),
-            code = """println(Paths.get("").toAbsolutePath().toString())"""
-        ), result)
+        assertEquals("""println(Paths.get("").toAbsolutePath().toString())""", result.code)
+        assertEquals(CodeInjectionSite.DEFAULT, result.site)
+        assertEquals(listOf("java.nio.file.Paths"), result.importsOrEmpty)
     }
 
     @Test
     fun `read install snippet code contents`() {
         val result = pluginCodeAnalyzer.parseInstallSnippet(
-            CodeInjectionSite.OUTSIDE_APP,
             KOTLIN_CODE.trimIndent(),
-            "Test.kt"
+            CodeInjectionSite.OUTSIDE_APP.asMeta(file = "Test.kt"),
         )
 
-        assertEquals(
-            InstallSnippet.Kotlin(
-            imports = listOf("java.nio.file.Paths"),
-            code = """
-                public fun pwd() {
-                    println(Paths.get("").toAbsolutePath().toString())
-                }
-            """.trimIndent()
-        ), result)
+        assertEquals("""
+            public fun pwd() {
+                println(Paths.get("").toAbsolutePath().toString())
+            }
+        """.trimIndent(), result.code)
+        assertEquals(CodeInjectionSite.OUTSIDE_APP, result.site)
+        assertEquals(listOf("java.nio.file.Paths"), result.importsOrEmpty)
     }
 }

--- a/src/test/resources/server/org.jetbrains/exposed/2.2/ExposedUser.kt
+++ b/src/test/resources/server/org.jetbrains/exposed/2.2/ExposedUser.kt
@@ -1,0 +1,4 @@
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ExposedUser(val name: String, val age: Int)

--- a/src/test/resources/server/org.jetbrains/exposed/2.2/UsersSchema.kt
+++ b/src/test/resources/server/org.jetbrains/exposed/2.2/UsersSchema.kt
@@ -1,0 +1,54 @@
+import kotlinx.coroutines.Dispatchers
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.sql.transactions.transaction
+
+class UserService(database: Database) {
+    object Users : Table() {
+        val id = integer("id").autoIncrement()
+        val name = varchar("name", length = 50)
+        val age = integer("age")
+
+        override val primaryKey = PrimaryKey(id)
+    }
+
+    init {
+        transaction(database) {
+            SchemaUtils.create(Users)
+        }
+    }
+
+    suspend fun create(user: ExposedUser): Int = dbQuery {
+        Users.insert {
+            it[name] = user.name
+            it[age] = user.age
+        }[Users.id]
+    }
+
+    suspend fun read(id: Int): ExposedUser? {
+        return dbQuery {
+            Users.select { Users.id eq id }
+                .map { ExposedUser(it[Users.name], it[Users.age]) }
+                .singleOrNull()
+        }
+    }
+
+    suspend fun update(id: Int, user: ExposedUser) {
+        dbQuery {
+            Users.update({ Users.id eq id }) {
+                it[name] = user.name
+                it[age] = user.age
+            }
+        }
+    }
+
+    suspend fun delete(id: Int) {
+        dbQuery {
+            Users.deleteWhere { Users.id.eq(id) }
+        }
+    }
+
+    private suspend fun <T> dbQuery(block: suspend () -> T): T =
+        newSuspendedTransaction(Dispatchers.IO) { block() }
+}

--- a/src/test/resources/server/org.jetbrains/exposed/2.2/documentation.md
+++ b/src/test/resources/server/org.jetbrains/exposed/2.2/documentation.md
@@ -1,0 +1,33 @@
+
+Exposed is a lightweight SQL library on top of [JDBC](https://en.wikipedia.org/wiki/Java_Database_Connectivity) driver for Kotlin language. Exposed has two flavors of database access: typesafe SQL wrapping DSL and lightweight Data Access Objects (DAO).
+
+With Exposed, you can have two levels of databases Access. You would like to use exposed because the database access includes wrapping DSL and a lightweight data access object. Exposed can be used to help you build applications without dependencies on any specific database engine and switch between them with very little or no changes.
+
+## Usage
+
+### Creating a table
+```kotlin
+object Users : Table() {
+    val id = varchar("id", 10) // Column<String>
+    val name = varchar("name", length = 50) // Column<String>
+    val cityId = (integer("city_id") references Cities.id).nullable() // Column<Int?>
+
+    override val primaryKey = PrimaryKey(id, name = "PK_User_ID") // name is optional here
+}
+```
+The above code snippet defines a table called "Users" with three columns: `id`, `name``, and `cityId``. The primary key for the table is defined as the `id` column, and the references function is used to define a foreign key constraint between the `cityId` column and the `id` column of the `Cities` table [(see full example)](https://github.com/JetBrains/Exposed).
+### Connecting to the database
+```kotlin
+Database.connect("jdbc:h2:mem:test", driver = "org.h2.Driver", user = "root", password = "")
+```
+The above code snippet connects to the database using the `Database.connect()` function, which takes the [JDBC](https://en.wikipedia.org/wiki/Java_Database_Connectivity) connection string, the `driver` class, and the `user` and `password` as its parameters. You can use any other database by changing the connection string and driver accordingly.
+### Performing a transaction
+```kotlin
+transaction {
+    Users.insert {
+        it[name] = user.name
+        it[age] = user.age
+    }
+}
+```
+The above code snippet shows how to perform a transaction using the `transaction` function. Inside the `transaction` block, you can perform any database operations

--- a/src/test/resources/server/org.jetbrains/exposed/2.2/inside_app.kt
+++ b/src/test/resources/server/org.jetbrains/exposed/2.2/inside_app.kt
@@ -1,0 +1,9 @@
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import org.jetbrains.exposed.sql.*
+
+public fun Application.install(database: Database) {
+    val userService = UserService(database)
+}

--- a/src/test/resources/server/org.jetbrains/exposed/2.2/install.kt
+++ b/src/test/resources/server/org.jetbrains/exposed/2.2/install.kt
@@ -1,0 +1,14 @@
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import org.jetbrains.exposed.sql.*
+
+public fun Application.configureDatabases() {
+    val database = Database.connect(
+        url = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1",
+        user = "root",
+        driver = "org.h2.Driver",
+        password = "",
+    )
+}

--- a/src/test/resources/server/org.jetbrains/exposed/2.2/manifest.ktor.yaml
+++ b/src/test/resources/server/org.jetbrains/exposed/2.2/manifest.ktor.yaml
@@ -3,12 +3,11 @@ description: Adds Exposed database to your application
 vcsLink: https://github.com/JetBrains/Exposed
 license: Apache 2.0
 category: Databases
-prerequisites:
-  - routing
-  - kotlinx-serialization
 installation:
   default: install.kt
   inside_app: inside_app.kt
   in_routing: routing.kt
 sources:
   - file: UsersSchema.kt
+  - file: ExposedUser.kt
+    module: common

--- a/src/test/resources/server/org.jetbrains/exposed/2.2/routing.kt
+++ b/src/test/resources/server/org.jetbrains/exposed/2.2/routing.kt
@@ -1,0 +1,41 @@
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import org.jetbrains.exposed.sql.*
+
+public fun Routing.configureRouting(userService: UserService) {
+    // Create user
+    post("/users") {
+        val user = call.receive<ExposedUser>()
+        val id = userService.create(user)
+        call.respond(HttpStatusCode.Created, id)
+    }
+
+    // Read user
+    get("/users/{id}") {
+        val id = call.parameters["id"]?.toInt() ?: throw IllegalArgumentException("Invalid ID")
+        val user = userService.read(id)
+        if (user != null) {
+            call.respond(HttpStatusCode.OK, user)
+        } else {
+            call.respond(HttpStatusCode.NotFound)
+        }
+    }
+
+    // Update user
+    put("/users/{id}") {
+        val id = call.parameters["id"]?.toInt() ?: throw IllegalArgumentException("Invalid ID")
+        val user = call.receive<ExposedUser>()
+        userService.update(id, user)
+        call.respond(HttpStatusCode.OK)
+    }
+
+    // Delete user
+    delete("/users/{id}") {
+        val id = call.parameters["id"]?.toInt() ?: throw IllegalArgumentException("Invalid ID")
+        userService.delete(id)
+        call.respond(HttpStatusCode.OK)
+    }
+}

--- a/src/test/resources/server/org.jetbrains/exposed/versions.ktor.yaml
+++ b/src/test/resources/server/org.jetbrains/exposed/versions.ktor.yaml
@@ -1,0 +1,7 @@
+"[2.2,)":
+  - org.jetbrains.exposed:exposed-core:$exposed
+  - org.jetbrains.exposed:exposed-jdbc:$exposed
+  - com.h2database:h2:$h2
+
+exposed: 0.53.+
+h2: 2.2.224

--- a/src/test/resources/server/org.jetbrains/group.ktor.yaml
+++ b/src/test/resources/server/org.jetbrains/group.ktor.yaml
@@ -1,0 +1,4 @@
+name: JetBrains
+url: https://jetbrains.org/
+email: ktor@jetbrains.com
+logo: icon.svg

--- a/src/test/resources/server/org.jetbrains/icon.svg
+++ b/src/test/resources/server/org.jetbrains/icon.svg
@@ -1,0 +1,16 @@
+<!--
+  - Copyright 2014-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+  -->
+
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="none" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="a" x1=".425" x2="31.31" y1="31.36" y2=".905" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF9419"/>
+      <stop offset=".43" stop-color="#FF021D"/>
+      <stop offset=".99" stop-color="#E600FF"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#a)" d="m10.17 1.83-8.34 8.34C.66 11.34 0 12.93 0 14.59V29.5C0 30.88 1.12 32 2.5 32h14.91c1.66 0 3.245-.66 4.42-1.83l8.34-8.34c1.17-1.17 1.83-2.76 1.83-4.42V2.5C32 1.12 30.88 0 29.5 0H14.59c-1.66 0-3.245.66-4.42 1.83Z"/>
+  <path fill="#000" d="M24 8H4v20h20V8Z"/>
+  <path fill="#fff" d="M15 24H6v2h9v-2Z"/>
+</svg>

--- a/templates/manifest.ktor.yaml
+++ b/templates/manifest.ktor.yaml
@@ -56,9 +56,20 @@ maven:
 #   - outside_app: top-level of main kotlin file, outside application scope
 #   - call_logging_config: inside the call logging configuration block
 #   - serialization_config: inside the serialization configuration block
-#   - source_file_kt: in a separate file
 #   - test_function: adds a function to the test suite
 #   - resources: adds a file to the project's resources
 # Optional, defaults to "default: install.kt"
 installation:
   default: install.kt
+# Set of additional source files to include in the project
+sources:
+  # Relative path in the plugin folder; maps to the corresponding folder in the project
+  - file: path/to/File.kt
+    # Platform or additional module:
+    #  - server (default)
+    #  - web
+    module: server
+    # Boolean attribute to indicate this source will be sent to the test sources (default false)
+    test: false
+# Same structure as "sources", but files are included under the project's resources folder
+resources: []

--- a/templates/schema/manifest-schema.json
+++ b/templates/schema/manifest-schema.json
@@ -118,6 +118,48 @@
         }
       }
     },
+    "sources": {
+      "description": "List of custom source file paths with multi-module support",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "Path to the file"
+          },
+          "module": {
+            "type": "string",
+            "description": "The target module where the file should be created"
+          },
+          "test": {
+            "type": "boolean",
+            "description": "Whether this should be created under the test sources"
+          }
+        }
+      }
+    },
+    "resources": {
+      "description": "List of custom source file paths with multi-module support",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "Path to the file"
+          },
+          "module": {
+            "type": "string",
+            "description": "The target module where the file should be created"
+          },
+          "test": {
+            "type": "boolean",
+            "description": "Whether this should be created under the test sources"
+          }
+        }
+      }
+    },
     "documentation": {
       "description": "Markdown string or file reference to populate the plugin details. Must include a 'Usage' header.",
       "type": "string"


### PR DESCRIPTION
This tackles this issue:

- [KTOR-7490](https://youtrack.jetbrains.com/issue/KTOR-7490) Project generator: source file definitions

It was noticed by @Mr3zee when attempting to introduce the kRPC plugin.  With this change, you can now add multiple source files to the plugin's sample code, and also target which module you'd like it in when using multi-platform support (i.e., "common"), which should make a little more sense in the next PR for the back end.