### PR TITLE
Add KHealth server plugin

### DIFF
--- a/plugins/server/dev.hayden/group.ktor.yaml
+++ b/plugins/server/dev.hayden/group.ktor.yaml
@@ -1,0 +1,3 @@
+name: Hayden Meloche
+url: https://hayden.dev
+email: meloche.hayden@gmail.com

--- a/plugins/server/dev.hayden/khealth/2.0/documentation.md
+++ b/plugins/server/dev.hayden/khealth/2.0/documentation.md
@@ -1,0 +1,115 @@
+# KHealth
+[![Release](https://jitpack.io/v/haydenmeloche/khealth.svg)](https://jitpack.io/#dev.hayden/khealth)
+
+KHealth is a simple & customizable health plugin for Ktor.
+
+## Usage
+
+```kotlin
+import dev.hayden.KHealth
+
+fun main(args: Array<String>) {
+  embeddedServer(Netty, 80) {
+    install(KHealth)
+  }.start(wait = true)
+}
+```
+
+This will configure a `/ready` and a `/health` endpoint both returning a `200` status code.
+
+KHealth also supports adding custom checks to both the ready and health endpoints.
+
+```kotlin
+import dev.hayden.KHealth
+
+fun main(args: Array<String>) {
+  embeddedServer(Netty, 80) {
+    install(KHealth) {
+      readyChecks {
+        check("check my database is up") {
+          myDatabase.ping()
+        }
+      }
+      healthChecks {
+        check("another check") { true }
+      }
+    }
+  }.start(wait = true)
+}
+```
+
+A `GET /ready` call would return
+
+```json
+{
+  "check my database is up": true
+}
+```
+
+and a `200` status code.
+
+If any provided checks return `false` then a 500 would be returned.
+
+If you'd like to override the default status codes, that can be done by overriding the default values.
+```kotlin
+import dev.hayden.KHealth
+
+fun main(args: Array<String>) {
+  embeddedServer(Netty, 80) {
+    install(KHealth) { 
+      successfulCheckStatusCode = HttpStatusCode.Accepted
+      unsuccessfulCheckStatusCode = HttpStatusCode.ExpectationFailed
+    }
+  }.start(wait = true)
+}
+```
+The health endpoint and ready endpoint can both be disabled using the `healthCheckEnabled` and
+`readyCheckEnabled` properties.
+
+```kotlin
+import dev.hayden.KHealth
+
+fun main(args: Array<String>) {
+  embeddedServer(Netty, 80) {
+    install(KHealth) {
+      readyCheckEnabled = false
+      healthCheckEnabled = false
+    }
+  }.start(wait = true)
+}
+```
+
+If you need to override the default URI paths, that can be done too.
+
+```kotlin
+import dev.hayden.KHealth
+
+fun main(args: Array<String>) {
+  embeddedServer(Netty, 80) {
+    install(KHealth) {
+      readyCheckPath = "newready"
+      healthCheckPath = "/newhealth"
+    }
+  }.start(wait = true)
+}
+```
+
+For more advanced configurations, KHealth accepts a Ktor `Route` allowing you to wrap the routes
+created by KHealth. An example of this is shown below adding basic authentication to the KHealth
+endpoints.
+
+```kotlin
+authentication {
+    basic(name = "basic auth") {
+        validate { credentials ->
+            // your logic here
+        }
+    }
+}
+install(KHealth) {
+    wrap {
+        // wrap our KHealth endpoints with an authentication block
+        authenticate("basic auth", optional = false, build = it)
+    }
+}
+```

--- a/plugins/server/dev.hayden/khealth/2.0/install.kt
+++ b/plugins/server/dev.hayden/khealth/2.0/install.kt
@@ -1,0 +1,7 @@
+import io.ktor.server.application.*
+import dev.hayden.KHealth
+
+// The contents of the `install` function will be used for the project template
+public fun Application.install() {
+    install(KHealth)
+}

--- a/plugins/server/dev.hayden/khealth/2.0/manifest.ktor.yaml
+++ b/plugins/server/dev.hayden/khealth/2.0/manifest.ktor.yaml
@@ -1,0 +1,12 @@
+name: KHealth
+description: A simple and customizable health plugin
+vcsLink: https://github.com/HaydenMeloche/khealth
+license: MIT
+category: Monitoring
+gradle:
+  repositories:
+    - url: https://jitpack.io
+maven:
+  repositories:
+    - id: jitpack
+      url: https://jitpack.io

--- a/plugins/server/dev.hayden/khealth/3.0/documentation.md
+++ b/plugins/server/dev.hayden/khealth/3.0/documentation.md
@@ -1,0 +1,115 @@
+# KHealth
+[![Release](https://jitpack.io/v/haydenmeloche/khealth.svg)](https://jitpack.io/#dev.hayden/khealth)
+
+KHealth is a simple & customizable health plugin for Ktor.
+
+## Usage
+
+```kotlin
+import dev.hayden.KHealth
+
+fun main(args: Array<String>) {
+  embeddedServer(Netty, 80) {
+    install(KHealth)
+  }.start(wait = true)
+}
+```
+
+This will configure a `/ready` and a `/health` endpoint both returning a `200` status code.
+
+KHealth also supports adding custom checks to both the ready and health endpoints.
+
+```kotlin
+import dev.hayden.KHealth
+
+fun main(args: Array<String>) {
+  embeddedServer(Netty, 80) {
+    install(KHealth) {
+      readyChecks {
+        check("check my database is up") {
+          myDatabase.ping()
+        }
+      }
+      healthChecks {
+        check("another check") { true }
+      }
+    }
+  }.start(wait = true)
+}
+```
+
+A `GET /ready` call would return
+
+```json
+{
+  "check my database is up": true
+}
+```
+
+and a `200` status code.
+
+If any provided checks return `false` then a 500 would be returned.
+
+If you'd like to override the default status codes, that can be done by overriding the default values.
+```kotlin
+import dev.hayden.KHealth
+
+fun main(args: Array<String>) {
+  embeddedServer(Netty, 80) {
+    install(KHealth) { 
+      successfulCheckStatusCode = HttpStatusCode.Accepted
+      unsuccessfulCheckStatusCode = HttpStatusCode.ExpectationFailed
+    }
+  }.start(wait = true)
+}
+```
+The health endpoint and ready endpoint can both be disabled using the `healthCheckEnabled` and
+`readyCheckEnabled` properties.
+
+```kotlin
+import dev.hayden.KHealth
+
+fun main(args: Array<String>) {
+  embeddedServer(Netty, 80) {
+    install(KHealth) {
+      readyCheckEnabled = false
+      healthCheckEnabled = false
+    }
+  }.start(wait = true)
+}
+```
+
+If you need to override the default URI paths, that can be done too.
+
+```kotlin
+import dev.hayden.KHealth
+
+fun main(args: Array<String>) {
+  embeddedServer(Netty, 80) {
+    install(KHealth) {
+      readyCheckPath = "newready"
+      healthCheckPath = "/newhealth"
+    }
+  }.start(wait = true)
+}
+```
+
+For more advanced configurations, KHealth accepts a Ktor `Route` allowing you to wrap the routes
+created by KHealth. An example of this is shown below adding basic authentication to the KHealth
+endpoints.
+
+```kotlin
+authentication {
+    basic(name = "basic auth") {
+        validate { credentials ->
+            // your logic here
+        }
+    }
+}
+install(KHealth) {
+    wrap {
+        // wrap our KHealth endpoints with an authentication block
+        authenticate("basic auth", optional = false, build = it)
+    }
+}
+```

--- a/plugins/server/dev.hayden/khealth/3.0/install.kt
+++ b/plugins/server/dev.hayden/khealth/3.0/install.kt
@@ -1,0 +1,7 @@
+import io.ktor.server.application.*
+import dev.hayden.KHealth
+
+// The contents of the `install` function will be used for the project template
+public fun Application.install() {
+    install(KHealth)
+}

--- a/plugins/server/dev.hayden/khealth/3.0/manifest.ktor.yaml
+++ b/plugins/server/dev.hayden/khealth/3.0/manifest.ktor.yaml
@@ -1,0 +1,12 @@
+name: KHealth
+description: A simple and customizable health plugin
+vcsLink: https://github.com/HaydenMeloche/khealth
+license: MIT
+category: Monitoring
+gradle:
+  repositories:
+    - url: https://jitpack.io
+maven:
+  repositories:
+    - id: jitpack
+      url: https://jitpack.io

--- a/plugins/server/dev.hayden/khealth/versions.ktor.yaml
+++ b/plugins/server/dev.hayden/khealth/versions.ktor.yaml
@@ -1,0 +1,6 @@
+# This file maps ktor versions to the required artifacts
+# See templates/versions.ktor.yaml for more details
+"[2.0,)": dev.hayden:khealth:2.1.+
+"[2.1,)": dev.hayden:khealth:2.1.+
+"[2.2,)": dev.hayden:khealth:2.1.+
+"[3.0,)": dev.hayden:khealth:3.0.+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ dependencyResolutionManagement {
             name = "SpaceKotlinJsWrappers"
         }
         maven("https://packages.confluent.io/maven/")
+        maven("https://jitpack.io")
     }
 }
 


### PR DESCRIPTION
Adding [KHealth plugin](https://github.com/HaydenMeloche/khealth).

I was able to run `buildRegistry` and see my project build. I was unable to get `buildTestProject` to generate anything. 

"No plugins changed or provided for test project generation" appeared in the logs but I wasn't sure exactly how to fix that.

Thanks! 😄 