### PR TITLE
Fix ktor sessions plugin template missing @Serializable

### DIFF
--- a/plugins/server/io.ktor/ktor-sessions/2.0/MySession.kt
+++ b/plugins/server/io.ktor/ktor-sessions/2.0/MySession.kt
@@ -1,0 +1,4 @@
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MySession(val count: Int = 0)

--- a/plugins/server/io.ktor/ktor-sessions/2.0/install.kt
+++ b/plugins/server/io.ktor/ktor-sessions/2.0/install.kt
@@ -1,9 +1,7 @@
 import io.ktor.server.application.*
-import io.ktor.server.response.*
 import io.ktor.server.sessions.*
 
 public fun Application.configureSecurity() {
-    data class MySession(val count: Int = 0)
     install(Sessions) {
         cookie<MySession>("MY_SESSION") {
             cookie.extensions["SameSite"] = "lax"

--- a/plugins/server/io.ktor/ktor-sessions/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/ktor-sessions/2.0/manifest.ktor.yaml
@@ -8,3 +8,4 @@ prerequisites:
 installation:
   default: install.kt
   in_routing: routing.kt
+  outside_app: MySession.kt

--- a/plugins/server/io.ktor/ktor-sessions/2.0/routing.kt
+++ b/plugins/server/io.ktor/ktor-sessions/2.0/routing.kt
@@ -1,11 +1,6 @@
-import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
-import kotlinx.serialization.*
-
-@Serializable
-data class MySession(val count: Int = 0)
 
 public fun Routing.configureRouting(mySession: MySession) {
     get("/session/increment") {


### PR DESCRIPTION
Fixes this issue https://github.com/ktorio/ktor-plugin-registry/issues/130

This moves the `MySession` class outside the module function and uses the proper `@Serializable` annotation.