### PR TITLE
Add automatic test project support for forks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,6 +99,7 @@ dependencies {
 
     // finding changed files
     implementation(libs.jgit)
+    implementation(libs.jgit.ssh.apache)
 
     testImplementation(kotlin("test"))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml-version" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-version" }
 maven-artifact = { module = "org.apache.maven:maven-artifact", version.ref = "maven-artifact-version" }
 jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit-version" }
+jgit-ssh-apache = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache", version.ref = "jgit-version" }
 apache-compress = { module = "org.apache.commons:commons-compress", version.ref = "compress-version" }
 
 [plugins]

--- a/src/main/kotlin/io/ktor/plugins/registry/GenerateTestProject.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/GenerateTestProject.kt
@@ -36,7 +36,7 @@ fun main(args: Array<String>) {
     ), args)
 
     val pluginIds = argsMap["plugins"]?.split(",")
-        ?: GitSupport.getChangedPluginIds(compareBranch = argsMap["branch"]!!)
+        ?: GitSupport.getChangedPluginIds(mainBranchName = argsMap["branch"]!!)
 
     if (pluginIds.isEmpty()) {
         logger.info("No plugins changed or provided for test project generation")

--- a/src/main/kotlin/io/ktor/plugins/registry/utils/GitSupport.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/utils/GitSupport.kt
@@ -4,6 +4,8 @@
 
 package io.ktor.plugins.registry.utils
 
+import io.ktor.plugins.registry.utils.GitSupport.Remote.Main
+import io.ktor.plugins.registry.utils.GitSupport.Remote.Fork
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.diff.DiffFormatter
 import org.eclipse.jgit.lib.Repository
@@ -27,19 +29,16 @@ object GitSupport {
      */
     fun getChangedPluginIds(
         mainBranchName: String = "main",
+        expectedRemoteGroup: String = "ktorio",
         target: String = "server",
-        defaultOrigin: String = "origin"
     ): List<String> {
-        val repository = Git.open(File("")).repository
+        val git = Git.open(File(""))
+        val repository = git.repository
         val currentIndex = FileTreeIterator(repository)
-        val remoteName = repository.config.getSubsections("remote").takeIf { it.size > 1 }?.last { it != defaultOrigin }
-        val mainBranch = when(remoteName) {
-            null -> getTreeIteratorForBranch(repository, mainBranchName)
-            else -> getTreeIteratorForRemoteBranch(repository, mainBranchName, remoteName)
-        }
+        val mainTree = git.getMainTree(repository, mainBranchName, expectedRemoteGroup)
         val diffEntries = DiffFormatter(DisabledOutputStream.INSTANCE).run {
             setRepository(repository)
-            scan(currentIndex, mainBranch)
+            scan(currentIndex, mainTree)
         }
 
         val extractPluginId = Regex("plugins/$target/[^/]+/([^/]+).*")
@@ -50,6 +49,59 @@ object GitSupport {
         }.distinct()
 
         return changedPluginIds.toList()
+    }
+
+    private fun Git.getMainTree(
+        repository: Repository,
+        mainBranchName: String,
+        expectedRemoteGroup: String,
+    ): AbstractTreeIterator {
+        val remotes = getRemotes(repository, expectedRemoteGroup)
+
+        return when(remotes) {
+            // when there is no upstream, we must add it
+            is Fork -> {
+                addRemoteUrl("upstream", remotes.url.replaceGitName(expectedRemoteGroup))
+                getTreeIteratorForRemoteBranch(repository, mainBranchName, "upstream")
+            }
+            // when only main repository, we only need to compare branches
+            is Main -> getTreeIteratorForBranch(repository, mainBranchName)
+            // compare with upstream normally
+            is Remotes.MainAndFork -> getTreeIteratorForRemoteBranch(repository, mainBranchName, remotes.main)
+            is Remotes.Multiple -> throw IllegalArgumentException("Multiple remotes found, can't infer changes")
+            is Remotes.None -> throw IllegalArgumentException("Couldn't find remotes, can't infer changes")
+        }
+    }
+
+    private fun getRemotes(repo: Repository, expectedRemoteGroup: String): Remotes {
+        val config = repo.config
+        return config.getSubsections("remote").map { remoteName ->
+            val remoteUrl = config.getString("remote", remoteName, "url")
+            when(remoteUrl.gitUsername) {
+                expectedRemoteGroup -> Main(remoteName, remoteUrl)
+                else -> Fork(remoteName, remoteUrl)
+            }
+        }.run {
+            if (isEmpty())
+                Remotes.None
+            when(size) {
+                1 -> get(0)
+                2 -> firstOrNull { it is Main }?.let { main ->
+                    Remotes.MainAndFork(
+                        main.name,
+                        minus(main).first().name
+                    )
+                } ?: Remotes.Multiple
+                else -> Remotes.Multiple
+            }
+        }
+    }
+
+    private fun Git.addRemoteUrl(remoteName: String, remoteUrl: String) {
+        remoteAdd()
+            .setName(remoteName)
+            .setUri(org.eclipse.jgit.transport.URIish(remoteUrl))
+            .call()
     }
 
     private fun getTreeIteratorForBranch(repo: Repository, name: String): AbstractTreeIterator {
@@ -75,5 +127,37 @@ object GitSupport {
 
         return treeParser
     }
+
+    sealed interface Remotes {
+        data class MainAndFork(val main: String, val upstream: String): Remotes
+        data object Multiple: Remotes
+        data object None: Remotes
+    }
+
+    sealed class Remote(
+        val name: String,
+        val url: String
+    ): Remotes {
+
+        class Main(name: String, url: String): Remote(name, url)
+        class Fork(name: String, url: String): Remote(name, url)
+    }
+
+    private val sshRegex = Regex("""git@github\.com:([^/]+)/.+?\.git""")
+    private val httpsRegex = Regex("""https://github\.com/([^/]+)/.+?\.git""")
+
+    private fun String.replaceGitName(newValue: String): String {
+        val currentName = (sshRegex.matchEntire(this) ?: httpsRegex.matchEntire(this))?.let { match ->
+            match.groups[1]
+        } ?: throw IllegalArgumentException("Cannot infer username from $this")
+
+        return replace(currentName.value, newValue)
+    }
+    private val String.gitUsername: String
+        get() {
+            return (sshRegex.matchEntire(this) ?: httpsRegex.matchEntire(this))?.let { match ->
+                match.groups[1]?.value
+            } ?: throw IllegalArgumentException("Cannot infer username from $this")
+        }
 
 }

--- a/src/main/kotlin/io/ktor/plugins/registry/utils/GitSupport.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/utils/GitSupport.kt
@@ -93,9 +93,8 @@ object GitSupport {
                 else -> Fork(remoteName, remoteUrl)
             }
         }.run {
-            if (isEmpty())
-                Remotes.None
             when(size) {
+                0 -> Remotes.None
                 1 -> get(0)
                 2 -> firstOrNull { it is Main }?.let { main ->
                     Remotes.MainAndFork(

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -8,5 +8,7 @@
         <appender-ref ref="STDOUT"/>
     </root>
     <logger name="org.eclipse.jetty" level="INFO"/>
+    <!-- JGit is quite spammy -->
+    <logger name="org.eclipse.jgit" level="ERROR"/>
     <logger name="io.netty" level="INFO"/>
 </configuration>


### PR DESCRIPTION
Now the `buildTestProject` gradle task will actually generate a proper test project based on what has changed between your local changes and the upstream / main.  Previously, this was only working with branches off the main repository.  A significant oversight on my part 🤦 