### PR TITLE
KTOR-7486 Fix kotlin version references for plugins

### DIFF
--- a/buildSrc/src/main/kotlin/io/ktor/plugins/registry/PluginConfigurations.kt
+++ b/buildSrc/src/main/kotlin/io/ktor/plugins/registry/PluginConfigurations.kt
@@ -132,7 +132,7 @@ private fun readPluginConfigs(
             it.module == module || (it.module == null && module == type)
         }.map {
             when (it.version) {
-                is MatchKtor -> it.resolve(release)
+                is KtorVersion -> it.resolve(release)
                 else -> it
             }
         }.toList()

--- a/detekt.yml
+++ b/detekt.yml
@@ -167,8 +167,8 @@ complexity:
   TooManyFunctions:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
-    thresholdInFiles: 11
-    thresholdInClasses: 11
+    thresholdInFiles: 15
+    thresholdInClasses: 15
     thresholdInInterfaces: 11
     thresholdInObjects: 11
     thresholdInEnums: 11

--- a/plugins/client/io.ktor/client-serialization-json-kotlinx/2.0/manifest.ktor.yaml
+++ b/plugins/client/io.ktor/client-serialization-json-kotlinx/2.0/manifest.ktor.yaml
@@ -6,12 +6,12 @@ category: Serialization
 gradle:
   plugins:
     - id: org.jetbrains.kotlin.plugin.serialization
-      version: LAST_KOTLIN_VERSION
+      version: $kotlin_version
 maven:
   plugins:
     - group: org.jetbrains.kotlin
       artifact: kotlin-maven-plugin
-      version: LAST_KOTLIN_VERSION
+      version: $kotlin_version
       extra: |-
         <executions>
             <execution>

--- a/plugins/gradle.properties
+++ b/plugins/gradle.properties
@@ -7,3 +7,7 @@ kotlinx-html=0.+
 mongo=4.10.+
 postgres=42.7.+
 prometheus=1.6.+
+
+# Determined by options during project creation
+ktor_version=3.0.1
+kotlin_version=2.0.21

--- a/plugins/server/io.ktor/kotlinx-serialization/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/kotlinx-serialization/2.0/manifest.ktor.yaml
@@ -11,12 +11,12 @@ installation:
 gradle:
   plugins:
     - id: org.jetbrains.kotlin.plugin.serialization
-      version: LAST_KOTLIN_VERSION
+      version: $kotlin_version
 maven:
   plugins:
     - group: org.jetbrains.kotlin
       artifact: kotlin-maven-plugin
-      version: LAST_KOTLIN_VERSION
+      version: $kotlin_version
       extra: |-
         <executions>
             <execution>

--- a/plugins/server/io.ktor/resources/2.0/manifest.ktor.yaml
+++ b/plugins/server/io.ktor/resources/2.0/manifest.ktor.yaml
@@ -12,12 +12,12 @@ installation:
 gradle:
   plugins:
     - id: org.jetbrains.kotlin.plugin.serialization
-      version: LAST_KOTLIN_VERSION
+      version: $kotlin_version
 maven:
   plugins:
     - group: org.jetbrains.kotlin
       artifact: kotlin-maven-plugin
-      version: LAST_KOTLIN_VERSION
+      version: $kotlin_version
       extra: |-
         <executions>
             <execution>

--- a/plugins/server/org.jetbrains/kotlinx-rpc/3.0/manifest.ktor.yaml
+++ b/plugins/server/org.jetbrains/kotlinx-rpc/3.0/manifest.ktor.yaml
@@ -12,13 +12,13 @@ amper:
 gradle:
   plugins:
     - id: org.jetbrains.kotlin.plugin.serialization
-      version: LAST_KOTLIN_VERSION
+      version: $kotlin_version
       module: core
     - id: org.jetbrains.kotlinx.rpc.plugin
       version: $kotlinx-rpc
       module: core
     - id: org.jetbrains.kotlin.plugin.serialization
-      version: LAST_KOTLIN_VERSION
+      version: $kotlin_version
       module: client
     - id: org.jetbrains.kotlinx.rpc.plugin
       version: $kotlinx-rpc


### PR DESCRIPTION
This introduces references to the Kotlin version from plugins, which will be resolved to the one supplied to the project generator when the project is created.
