### PR TITLE
KTOR-7944 Add kotlinx-browser for htmx plugin

### DIFF
--- a/plugins/gradle.properties
+++ b/plugins/gradle.properties
@@ -10,5 +10,5 @@ prometheus=1.6.+
 kotlinx-browser=0.3
 
 # Determined by options during project creation
-ktor_version=3.0.1
-kotlin_version=2.0.21
+ktor_version=3.0.2
+kotlin_version=2.1.0

--- a/plugins/gradle.properties
+++ b/plugins/gradle.properties
@@ -7,6 +7,7 @@ kotlinx-html=0.+
 mongo=4.10.+
 postgres=42.7.+
 prometheus=1.6.+
+kotlinx-browser=0.3
 
 # Determined by options during project creation
 ktor_version=3.0.1

--- a/plugins/server/org.jetbrains/htmx/versions.ktor.yaml
+++ b/plugins/server/org.jetbrains/htmx/versions.ktor.yaml
@@ -1,2 +1,4 @@
 "[3.0,)":
-  web: npm(htmx.org:2.0.3)
+  web:
+    - npm(htmx.org:2.0.3)
+    - org.jetbrains.kotlinx:kotlinx-browser:$kotlinx-browser

--- a/src/main/kotlin/io/ktor/plugins/registry/GenerateTestProject.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/GenerateTestProject.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import org.slf4j.LoggerFactory
+import kotlin.io.path.Path
 
 private const val GENERATE_URL = "https://start-ktor-io.labs.jb.gg/project/generate"
 private const val COMPARE_BRANCH = "main"
@@ -46,6 +47,7 @@ fun main(args: Array<String>) {
     logger.info("Creating project from plugins:\n${pluginIds.joinToString("\n") { " - $it" }}")
     val registryFiles = RegistryOutputFiles(argsMap["build-dir"]!!)
     val latestRelease = registryFiles.ktorReleases.last()
+    val versionProperties = Path("plugins").readVersionProperties()
 
     val generatorBackendUrl = argsMap["url"]!!
     val projectPath = argsMap["path"] ?: OUTPUT_DIR
@@ -57,6 +59,8 @@ fun main(args: Array<String>) {
             features = registryFiles.getAllRequiredPluginIds(latestRelease, pluginIds)
             featureOverrides = pluginIds.map { registryFiles.readManifest(latestRelease, it) }
             outputDir = projectPath
+            ktorVersion = versionProperties["ktor_version"]
+            kotlinVersion = versionProperties["kotlin_version"]
         }
     }
 

--- a/src/main/kotlin/io/ktor/plugins/registry/utils/ProjectGeneratorClient.kt
+++ b/src/main/kotlin/io/ktor/plugins/registry/utils/ProjectGeneratorClient.kt
@@ -26,7 +26,6 @@ private const val DEFAULT_PROJECT_WEBSITE = "ktor.io"
 private const val DEFAULT_BUILD_SYSTEM = "GRADLE_KTS"
 private const val DEFAULT_ENGINE = "NETTY"
 private const val DEFAULT_OUTPUT_DIR = "test-project"
-private const val DEFAULT_KOTLIN_VERSION = "1.9.23" // TODO get from gradle
 private const val DEFAULT_CONFIGURATION_OPTION = "HOCON"
 
 /**
@@ -40,8 +39,12 @@ class ProjectGeneratorClient(
 
     @OptIn(ExperimentalSerializationApi::class, ExperimentalPathApi::class)
     suspend fun generate(params: ProjectGeneratorRequestBuilder.() -> Unit) {
+
         ProjectGeneratorRequestBuilder().run {
             params()
+
+            require(kotlinVersion != null) { "Kotlin version must be specified" }
+            require(ktorVersion != null) { "Ktor version must be specified" }
 
             val response = httpClient.post(url) {
                 contentType(ContentType.Application.Json)
@@ -55,6 +58,9 @@ class ProjectGeneratorClient(
                         put("ktor_version", ktorVersion)
                         put("kotlin_version", kotlinVersion)
                         put("build_system", buildSystem)
+                        putJsonObject("build_system_args") {
+                            put("version_catalog", true)
+                        }
                         put("engine", engine)
                     }
                     put("configurationOption", configurationOption)
@@ -106,7 +112,7 @@ class ProjectGeneratorRequestBuilder {
     var engine: String = DEFAULT_ENGINE
     var outputDir: String = DEFAULT_OUTPUT_DIR
     var ktorVersion: String? = null
-    var kotlinVersion: String = DEFAULT_KOTLIN_VERSION
+    var kotlinVersion: String? = null
     var features: List<String> = emptyList()
     var featureOverrides: List<JsonObject> = emptyList()
     var configurationOption: String = DEFAULT_CONFIGURATION_OPTION


### PR DESCRIPTION
I guess the wasmJs browser target in the multiplatform gradle plugin was implicitly importing kotlinx-browser before, and has since stopped with the latest version.  Either that or I'm going crazy.