### PR TITLE
KTOR-7979 Remove -jvm from artifacts

### DIFF
--- a/plugins/client/io.ktor/client-call-logging/versions.ktor.yaml
+++ b/plugins/client/io.ktor/client-call-logging/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-client-logging-jvm:==
+"[2.0,)": ktor-client-logging:==

--- a/plugins/server/com.ucasoft/simple-redis-cache/versions.ktor.yaml
+++ b/plugins/server/com.ucasoft/simple-redis-cache/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": com.ucasoft.ktor:ktor-simple-redis-cache-jvm:0.+
+"[2.0,)": com.ucasoft.ktor:ktor-simple-redis-cache:0.+

--- a/plugins/server/io.ktor/auth-jwt/versions.ktor.yaml
+++ b/plugins/server/io.ktor/auth-jwt/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-auth-jwt-jvm:==
+"[2.0,)": ktor-server-auth-jwt:==

--- a/plugins/server/io.ktor/auth-ldap/versions.ktor.yaml
+++ b/plugins/server/io.ktor/auth-ldap/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-auth-ldap-jvm:==
+"[2.0,)": ktor-server-auth-ldap:==

--- a/plugins/server/io.ktor/auth-oauth/versions.ktor.yaml
+++ b/plugins/server/io.ktor/auth-oauth/versions.ktor.yaml
@@ -1,3 +1,3 @@
 "[2.0,)":
-  - io.ktor:ktor-client-core-jvm:==
-  - io.ktor:ktor-client-apache-jvm:==
+  - io.ktor:ktor-client-core:==
+  - io.ktor:ktor-client-apache:==

--- a/plugins/server/io.ktor/auth/versions.ktor.yaml
+++ b/plugins/server/io.ktor/auth/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-auth-jvm:==
+"[2.0,)": ktor-server-auth:==

--- a/plugins/server/io.ktor/auto-head-response/versions.ktor.yaml
+++ b/plugins/server/io.ktor/auto-head-response/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-auto-head-response-jvm:==
+"[2.0,)": ktor-server-auto-head-response:==

--- a/plugins/server/io.ktor/caching-headers/versions.ktor.yaml
+++ b/plugins/server/io.ktor/caching-headers/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-caching-headers-jvm:==
+"[2.0,)": ktor-server-caching-headers:==

--- a/plugins/server/io.ktor/call-logging/versions.ktor.yaml
+++ b/plugins/server/io.ktor/call-logging/versions.ktor.yaml
@@ -1,2 +1,2 @@
-"[2.0,3.0.0)": ktor-server-call-logging-jvm:==
-"[3.0.0,)": ktor-server-call-logging-jvm:==
+"[2.0,3.0.0)": ktor-server-call-logging:==
+"[3.0.0,)": ktor-server-call-logging:==

--- a/plugins/server/io.ktor/callid/versions.ktor.yaml
+++ b/plugins/server/io.ktor/callid/versions.ktor.yaml
@@ -1,2 +1,2 @@
-"[2.0,3.0)": ktor-server-call-id-jvm:==
-"[3.0,)": ktor-server-call-id-jvm:==
+"[2.0,3.0)": ktor-server-call-id:==
+"[3.0,)": ktor-server-call-id:==

--- a/plugins/server/io.ktor/compression/versions.ktor.yaml
+++ b/plugins/server/io.ktor/compression/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-compression-jvm:==
+"[2.0,)": ktor-server-compression:==

--- a/plugins/server/io.ktor/conditional-headers/versions.ktor.yaml
+++ b/plugins/server/io.ktor/conditional-headers/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-conditional-headers-jvm:==
+"[2.0,)": ktor-server-conditional-headers:==

--- a/plugins/server/io.ktor/content-negotiation/versions.ktor.yaml
+++ b/plugins/server/io.ktor/content-negotiation/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-content-negotiation-jvm:==
+"[2.0,)": ktor-server-content-negotiation:==

--- a/plugins/server/io.ktor/cors/versions.ktor.yaml
+++ b/plugins/server/io.ktor/cors/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-cors-jvm:==
+"[2.0,)": ktor-server-cors:==

--- a/plugins/server/io.ktor/csrf/versions.ktor.yaml
+++ b/plugins/server/io.ktor/csrf/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[3.0.0,)": ktor-server-csrf-jvm:==
+"[3.0.0,)": ktor-server-csrf:==

--- a/plugins/server/io.ktor/default-headers/versions.ktor.yaml
+++ b/plugins/server/io.ktor/default-headers/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-default-headers-jvm:==
+"[2.0,)": ktor-server-default-headers:==

--- a/plugins/server/io.ktor/double-receive/versions.ktor.yaml
+++ b/plugins/server/io.ktor/double-receive/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-double-receive-jvm:==
+"[2.0,)": ktor-server-double-receive:==

--- a/plugins/server/io.ktor/forwarded-header-support/versions.ktor.yaml
+++ b/plugins/server/io.ktor/forwarded-header-support/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-forwarded-header-jvm:==
+"[2.0,)": ktor-server-forwarded-header:==

--- a/plugins/server/io.ktor/freemarker/versions.ktor.yaml
+++ b/plugins/server/io.ktor/freemarker/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-freemarker-jvm:==
+"[2.0,)": ktor-server-freemarker:==

--- a/plugins/server/io.ktor/hsts/versions.ktor.yaml
+++ b/plugins/server/io.ktor/hsts/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-hsts-jvm:==
+"[2.0,)": ktor-server-hsts:==

--- a/plugins/server/io.ktor/https-redirect/versions.ktor.yaml
+++ b/plugins/server/io.ktor/https-redirect/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-http-redirect-jvm:==
+"[2.0,)": ktor-server-http-redirect:==

--- a/plugins/server/io.ktor/kotlinx-serialization/versions.ktor.yaml
+++ b/plugins/server/io.ktor/kotlinx-serialization/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-serialization-kotlinx-json-jvm:==
+"[2.0,)": ktor-serialization-kotlinx-json:==

--- a/plugins/server/io.ktor/ktor-gson/versions.ktor.yaml
+++ b/plugins/server/io.ktor/ktor-gson/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-serialization-gson-jvm:==
+"[2.0,)": ktor-serialization-gson:==

--- a/plugins/server/io.ktor/ktor-jackson/versions.ktor.yaml
+++ b/plugins/server/io.ktor/ktor-jackson/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-serialization-jackson-jvm:==
+"[2.0,)": ktor-serialization-jackson:==

--- a/plugins/server/io.ktor/ktor-network-tls/versions.ktor.yaml
+++ b/plugins/server/io.ktor/ktor-network-tls/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-network-tls-jvm:==
+"[2.0,)": ktor-network-tls:==

--- a/plugins/server/io.ktor/ktor-sessions/versions.ktor.yaml
+++ b/plugins/server/io.ktor/ktor-sessions/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-sessions-jvm:==
+"[2.0,)": ktor-server-sessions:==

--- a/plugins/server/io.ktor/ktor-websockets/versions.ktor.yaml
+++ b/plugins/server/io.ktor/ktor-websockets/versions.ktor.yaml
@@ -1,2 +1,2 @@
-"[2.0,3.0)": ktor-server-websockets-jvm:==
-"[3.0,)": ktor-server-websockets-jvm:==
+"[2.0,3.0)": ktor-server-websockets:==
+"[3.0,)": ktor-server-websockets:==

--- a/plugins/server/io.ktor/metrics-micrometer/versions.ktor.yaml
+++ b/plugins/server/io.ktor/metrics-micrometer/versions.ktor.yaml
@@ -1,3 +1,3 @@
 "[2.0,)":
-  - io.ktor:ktor-server-metrics-micrometer-jvm:==
+  - io.ktor:ktor-server-metrics-micrometer:==
   - io.micrometer:micrometer-registry-prometheus:$prometheus

--- a/plugins/server/io.ktor/metrics/versions.ktor.yaml
+++ b/plugins/server/io.ktor/metrics/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-metrics-jvm:==
+"[2.0,)": ktor-server-metrics:==

--- a/plugins/server/io.ktor/mustache/versions.ktor.yaml
+++ b/plugins/server/io.ktor/mustache/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-mustache-jvm:==
+"[2.0,)": ktor-server-mustache:==

--- a/plugins/server/io.ktor/partial-content/versions.ktor.yaml
+++ b/plugins/server/io.ktor/partial-content/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-partial-content-jvm:==
+"[2.0,)": ktor-server-partial-content:==

--- a/plugins/server/io.ktor/pebble/versions.ktor.yaml
+++ b/plugins/server/io.ktor/pebble/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.3,)": ktor-server-pebble-jvm:==
+"[2.3,)": ktor-server-pebble:==

--- a/plugins/server/io.ktor/resources/versions.ktor.yaml
+++ b/plugins/server/io.ktor/resources/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-resources-jvm:==
+"[2.0,)": ktor-server-resources:==

--- a/plugins/server/io.ktor/routing/versions.ktor.yaml
+++ b/plugins/server/io.ktor/routing/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-core-jvm:==
+"[2.0,)": ktor-server-core:==

--- a/plugins/server/io.ktor/sse/versions.ktor.yaml
+++ b/plugins/server/io.ktor/sse/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[3.0.0,)": ktor-server-sse-jvm:==
+"[3.0.0,)": ktor-server-sse:==

--- a/plugins/server/io.ktor/static-content/versions.ktor.yaml
+++ b/plugins/server/io.ktor/static-content/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-host-common-jvm:==
+"[2.0,)": ktor-server-host-common:==

--- a/plugins/server/io.ktor/status-pages/versions.ktor.yaml
+++ b/plugins/server/io.ktor/status-pages/versions.ktor.yaml
@@ -1,3 +1,3 @@
 "[2.0,)":
-  - io.ktor:ktor-server-host-common-jvm:==
-  - io.ktor:ktor-server-status-pages-jvm:==
+  - io.ktor:ktor-server-host-common:==
+  - io.ktor:ktor-server-status-pages:==

--- a/plugins/server/io.ktor/swagger/versions.ktor.yaml
+++ b/plugins/server/io.ktor/swagger/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.2,)": ktor-server-swagger-jvm:==
+"[2.2,)": ktor-server-swagger:==

--- a/plugins/server/io.ktor/thymeleaf/versions.ktor.yaml
+++ b/plugins/server/io.ktor/thymeleaf/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-thymeleaf-jvm:==
+"[2.0,)": ktor-server-thymeleaf:==

--- a/plugins/server/io.ktor/velocity/versions.ktor.yaml
+++ b/plugins/server/io.ktor/velocity/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": ktor-server-velocity-jvm:==
+"[2.0,)": ktor-server-velocity:==

--- a/plugins/server/io.ktor/webjars/versions.ktor.yaml
+++ b/plugins/server/io.ktor/webjars/versions.ktor.yaml
@@ -1,3 +1,3 @@
 "[2.0,)":
-  - io.ktor:ktor-server-webjars-jvm:==
+  - io.ktor:ktor-server-webjars:==
   - org.webjars:jquery:3.2.1

--- a/plugins/server/org.jetbrains/css-dsl/versions.ktor.yaml
+++ b/plugins/server/org.jetbrains/css-dsl/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": kotlin-css-jvm:1.0.0-pre.129-kotlin-1.4.20
+"[2.0,)": kotlin-css:1.0.0-pre.129-kotlin-1.4.20

--- a/plugins/server/org.jetbrains/html-dsl/versions.ktor.yaml
+++ b/plugins/server/org.jetbrains/html-dsl/versions.ktor.yaml
@@ -1,3 +1,3 @@
 "[2.0,)":
-  - io.ktor:ktor-server-html-builder-jvm:==
-  - org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinx-html
+  - io.ktor:ktor-server-html-builder:==
+  - org.jetbrains.kotlinx:kotlinx-html:$kotlinx-html


### PR DESCRIPTION
Since this suffix is only required for maven builds, we'll remove it by default and include it for maven as required.