### PR TITLE
Update CSS DSL library

### DIFF
--- a/plugins/server/org.jetbrains/css-dsl/2.0/install.kt
+++ b/plugins/server/org.jetbrains/css-dsl/2.0/install.kt
@@ -1,9 +1,4 @@
-import io.ktor.http.*
 import io.ktor.server.application.*
-import io.ktor.server.html.*
-import io.ktor.server.response.*
-import kotlinx.css.*
-import kotlinx.html.*
 
 public fun Application.configureTemplating() {
     

--- a/plugins/server/org.jetbrains/css-dsl/2.0/outside_app.kt
+++ b/plugins/server/org.jetbrains/css-dsl/2.0/outside_app.kt
@@ -1,11 +1,9 @@
 import io.ktor.http.*
 import io.ktor.server.application.*
-import io.ktor.server.html.*
 import io.ktor.server.response.*
-import kotlinx.css.*
-import kotlinx.html.*
+import kotlinx.css.CssBuilder
 
-suspend inline fun ApplicationCall.respondCss(builder: CSSBuilder.() -> Unit) {
-   this.respondText(CSSBuilder().apply(builder).toString(), ContentType.Text.CSS)
+suspend inline fun ApplicationCall.respondCss(builder: CssBuilder.() -> Unit) {
+   this.respondText(CssBuilder().apply(builder).toString(), ContentType.Text.CSS)
 }
 

--- a/plugins/server/org.jetbrains/css-dsl/2.0/routing.kt
+++ b/plugins/server/org.jetbrains/css-dsl/2.0/routing.kt
@@ -1,17 +1,17 @@
-import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.html.*
-import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.css.*
-import kotlinx.html.*
+import kotlinx.html.body
+import kotlinx.html.h1
+import kotlinx.html.head
+import kotlinx.html.link
 
 public fun Routing.configureRouting() {
     get("/styles.css") {
         call.respondCss {
             body {
                 backgroundColor = Color.darkBlue
-                margin(0.px)
+                margin = Margin(0.px)
             }
             rule("h1.page-title") {
                 color = Color.white

--- a/plugins/server/org.jetbrains/css-dsl/versions.ktor.yaml
+++ b/plugins/server/org.jetbrains/css-dsl/versions.ktor.yaml
@@ -1,1 +1,1 @@
-"[2.0,)": kotlin-css:1.0.0-pre.129-kotlin-1.4.20
+"[2.0,)": org.jetbrains.kotlin-wrappers:kotlin-css-jvm:2025.6.4


### PR DESCRIPTION
Looks like the artifacts for this library moved, so I've updated to the latest API.