### PR TITLE
chore: update documentation of Firebase auth module

### DIFF
--- a/plugins/server/com.kborowy/firebase-auth-provider/2.0/documentation.md
+++ b/plugins/server/com.kborowy/firebase-auth-provider/2.0/documentation.md
@@ -1,21 +1,21 @@
-Authentication provider for Firebase Auth module.
+Ktor authentication provider for Firebase Auth module.
 
 
 ## Usage
 
-You need to setup [Firebase](https://firebase.google.com/) project
-with [Authentication module](https://firebase.google.com/products/auth) enabled. See [sample project](https://github.com/krizzu/firebase-auth-provider/blob/main/sample/README.md) to learn more.
+A [Firebase](https://firebase.google.com/) project
+with [Authentication module](https://firebase.google.com/products/auth) is required.
+See [sample project](./sample/README.md) to learn more.
 
 ```kotlin
 install(Authentication) {
     firebase("my-auth") {
-        adminFile = File("path/to/admin/file.json")
-        realm = "Sample Server"
+        realm = "My Server"
 
-        /**
-         * A decoded and verified Firebase token.
-         * Can be used to get the uid and other user attributes available in the token.
-         */
+        setup {
+            // required, see configuration below 
+        }
+
         validate { token ->
             UserIdPrincipal(token.uid)
         }
@@ -23,10 +23,47 @@ install(Authentication) {
 }
 ```
 
-## API
+## Configuration
+
+The authentication provider requires initialization of a FirebaseApp instance. You can either:
+
+1. Provide an existing FirebaseApp instance, or
+
+2. Initialize a new instance using a service account file
+
+### Existing FirebaseApp instance
+
+Provide a pre-configured FirebaseApp instance:
+
+```kotlin
+firebase("auth-firebase") {
+    setup {
+        firebaseApp = FirebaseApp.getInstance()
+    }
+}
+```
+
+### Initialize FirebaseApp with admin file
+
+Provide a service account JSON file OR an `InputStream` containing the service account credentials.
+Optionally specify a `firebaseAppName` to identify your Firebase instance.
+
+```kotlin
+firebase(name = "auth-firebase", firebaseAppName = "my-fb-app") {
+    setup {
+        // Choose one initialization method:
+
+        adminFile = File("path/to/admin/file.json")
+        // OR
+        adminFileStream = myFile.inputStream()
+    }
+}
+
+```
+
+### Authentication Parameters
 
 | **Param** | **Required** | **Description**                                                                                                                                                                                                                          |
 |-----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| adminFile | Required | [File](https://docs.oracle.com/javase/8/docs/api/java/io/File.html) instance, pointing to your Service account for your Firebase project. See [sample project](https://github.com/krizzu/firebase-auth-provider/blob/main/sample/README.md) to learn more.                                        |
-| validate  | Required | Lambda receiving decoded and verified [FirebaseToken](https://firebase.google.com/docs/reference/admin/java/reference/com/google/firebase/auth/FirebaseToken), expected to return Principal, if user is authorized or null otherwise.    |
-| realm     | Optional | String describing the protected area or the scope of protection. This could be a message like "Access to the staging site" or similar, so that the user knows to which space they are trying to get access to. Defaults to "Ktor Server" |
+| validate  | Required     | Lambda receiving decoded and verified [FirebaseToken](https://firebase.google.com/docs/reference/admin/java/reference/com/google/firebase/auth/FirebaseToken), expected to return Principal, if user is authorized or null otherwise.    |
+| realm     | Optional     | String describing the protected area or the scope of protection. This could be a message like "Access to the staging site" or similar, so that the user knows to which space they are trying to get access to. Defaults to "Ktor Server" |

--- a/plugins/server/com.kborowy/firebase-auth-provider/2.0/manifest.ktor.yaml
+++ b/plugins/server/com.kborowy/firebase-auth-provider/2.0/manifest.ktor.yaml
@@ -1,5 +1,5 @@
 name: Firebase authentication
-description: Handles Firebase bearer authentication
+description: Authentication provider for Firebase Auth module
 vcsLink: https://github.com/krizzu/firebase-auth-provider
 license: Apache 2.0
 category: Security


### PR DESCRIPTION
I've updated the documentation to match the latest version the auth provider, already available in Maven Central.
